### PR TITLE
Missing "-get" for OpenVPN install on Debian 8.x

### DIFF
--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -317,7 +317,7 @@ else
 		if [[ "$VERSION_ID" = 'VERSION_ID="8"' ]]; then
 			echo "deb http://swupdate.openvpn.net/apt jessie main" > /etc/apt/sources.list.d/swupdate-openvpn.list
 			wget -O - https://swupdate.openvpn.net/repos/repo-public.gpg | apt-key add -
-			apt update
+			apt-get update
 		fi
 		# Ubuntu 12.04
 		if [[ "$VERSION_ID" = 'VERSION_ID="12.04"' ]]; then


### PR DESCRIPTION
Simple mistake which is not currently affecting performance or updating on Debian 8.x

The 3 others custom installations for lastest OpenVPN release got the "apt-get"; so it's only visual