### PR TITLE
OpenVPN 2.4 update

### DIFF
--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -258,14 +258,6 @@ else
 		yum install openvpn iptables openssl wget ca-certificates curl -y
 	fi
 		
-		# Install dependencies
-		pacman -Syu openvpn iptables openssl wget ca-certificates curl --needed --noconfirm
-		if [[ "$OS" = 'arch' ]]; then
-			touch /etc/iptables/iptables.rules # iptables won't start if this file does not exist
-			systemctl enable iptables
-			systemctl start iptables
-		fi
-	fi
 	# Find out if the machine uses nogroup or nobody for the permissionless group
 	if grep -qs "^nogroup:" /etc/group; then
 	        NOGROUP=nogroup

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -466,7 +466,7 @@ auth SHA256
 $CIPHER
 tls-server
 tls-version-min 1.2
-tls-cipher TLS-DHE-RSA-WITH-AES-128-GCM-SHA256
+tls-cipher TLS-ECDHE-ECDSA-WITH-AES-128-GCM-SHA256
 status openvpn.log
 verb 3" >> /etc/openvpn/server.conf
 
@@ -583,7 +583,7 @@ auth SHA256
 $CIPHER
 tls-client
 tls-version-min 1.2
-tls-cipher TLS-DHE-RSA-WITH-AES-128-GCM-SHA256
+tls-cipher TLS-ECDHE-ECDSA-WITH-AES-128-GCM-SHA256
 setenv opt block-outside-dns
 verb 3" >> /etc/openvpn/client-template.txt
 

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -216,25 +216,6 @@ else
 		read -p "DNS [1-5]: " -e -i 2 DNS
 	done
 	echo ""
-	echo "Choose what size of RSA key you want to use:"
-	echo "   1) 2048 bits (fastest)"
-	echo "   2) 3072 bits (recommended, best compromise)"
-	echo "   3) 4096 bits (most secure)"
-	while [[ $RSA_KEY_SIZE != "1" && $RSA_KEY_SIZE != "2" && $RSA_KEY_SIZE != "3" ]]; do
-		read -p "DH key size [1-3]: " -e -i 2 RSA_KEY_SIZE
-	done
-	case $RSA_KEY_SIZE in
-		1)
-		RSA_KEY_SIZE="2048"
-		;;
-		2)
-		RSA_KEY_SIZE="3072"
-		;;
-		3)
-		RSA_KEY_SIZE="4096"
-		;;
-	esac
-	echo ""
 	echo "Finally, tell me a name for the client certificate and configuration"
 	while [[ $CLIENT = "" ]]; do
 		echo "Please, use one word only, no special characters"

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -461,6 +461,7 @@ cert server.crt
 key server.key
 tls-auth tls-auth.key 0
 dh none
+ecdh-curve
 auth SHA256
 $CIPHER
 tls-server

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -201,7 +201,7 @@ else
 	read -p "Port: " -e -i 1194 PORT
 	echo ""
 	echo "What protocol do you want for OpenVPN?"
-	echo "Unless UDP is blocked, you should not use TCP (unnecessarily slower)"
+	echo "Unless UDP is blocked, you should not use TCP (slower)"
 	while [[ $PROTOCOL != "UDP" && $PROTOCOL != "TCP" ]]; do
 		read -p "Protocol [UDP/TCP]: " -e -i UDP PROTOCOL
 	done
@@ -215,67 +215,6 @@ else
 	while [[ $DNS != "1" && $DNS != "2" && $DNS != "3" && $DNS != "4" && $DNS != "5" ]]; do
 		read -p "DNS [1-5]: " -e -i 2 DNS
 	done
-	echo ""
-	echo "See https://github.com/Angristan/OpenVPN-install#encryption to learn more about "
-	echo "the encryption in OpenVPN and the choices I made in this script."
-	echo "Please note that all the choices proposed are secure (to a different degree)"
-	echo "and are still viable to date, unlike some default OpenVPN options"
-	echo ''
-	echo "Choose which cipher you want to use for the data channel:"
-	echo "   1) AES-128-GCM (fastest and sufficiently secure for everyone, recommended)"
-	echo "   2) AES-192-GCM"
-	echo "   3) AES-256-GCM"
-	echo "Alternatives to AES, use them only if you know what you're doing."
-	echo "They are relatively slower but as secure as AES."
-	echo "   4) CAMELLIA-128-CBC"
-	echo "   5) CAMELLIA-192-CBC"
-	echo "   6) CAMELLIA-256-CBC"
-	echo "   7) SEED-CBC"
-	while [[ $CIPHER != "1" && $CIPHER != "2" && $CIPHER != "3" && $CIPHER != "4" && $CIPHER != "5" && $CIPHER != "6" && $CIPHER != "7" ]]; do
-		read -p "Cipher [1-7]: " -e -i 1 CIPHER
-	done
-	case $CIPHER in
-		1)
-		CIPHER="cipher AES-128-GCM"
-		;;
-		2)
-		CIPHER="cipher AES-192-GCM"
-		;;
-		3)
-		CIPHER="cipher AES-256-GCM"
-		;;
-		4)
-		CIPHER="cipher CAMELLIA-128-CBC"
-		;;
-		5)
-		CIPHER="cipher CAMELLIA-192-CBC"
-		;;
-		6)
-		CIPHER="cipher CAMELLIA-256-CBC"
-		;;
-		5)
-		CIPHER="cipher SEED-CBC"
-		;;
-	esac
-	echo ""
-	echo "Choose what size of Diffie-Hellman key you want to use:"
-	echo "   1) 2048 bits (fastest)"
-	echo "   2) 3072 bits (recommended, best compromise)"
-	echo "   3) 4096 bits (most secure)"
-	while [[ $DH_KEY_SIZE != "1" && $DH_KEY_SIZE != "2" && $DH_KEY_SIZE != "3" ]]; do
-		read -p "DH key size [1-3]: " -e -i 2 DH_KEY_SIZE
-	done
-	case $DH_KEY_SIZE in
-		1)
-		DH_KEY_SIZE="2048"
-		;;
-		2)
-		DH_KEY_SIZE="3072"
-		;;
-		3)
-		DH_KEY_SIZE="4096"
-		;;
-	esac
 	echo ""
 	echo "Choose what size of RSA key you want to use:"
 	echo "   1) 2048 bits (fastest)"
@@ -469,7 +408,7 @@ tls-auth tls-auth.key 0
 dh none
 ecdh-curve
 auth SHA256
-$CIPHER
+cipher cipher AES-128-GCM
 tls-server
 tls-version-min 1.2
 tls-cipher TLS-ECDHE-ECDSA-WITH-AES-128-GCM-SHA256
@@ -586,7 +525,7 @@ persist-key
 persist-tun
 remote-cert-tls server
 auth SHA256
-$CIPHER
+cipher AES-128-GCM
 tls-client
 tls-version-min 1.2
 tls-cipher TLS-ECDHE-ECDSA-WITH-AES-128-GCM-SHA256

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -277,8 +277,9 @@ else
 	chown -R root:root /etc/openvpn/easy-rsa/
 	rm -rf ~/EasyRSA-3.0.1.tgz
 	cd /etc/openvpn/easy-rsa/
-	echo "set_var EASYRSA_ALGO ec
-set_var EASYRSA_CURVE secp384r1" > vars
+	echo 'set_var EASYRSA_ALGO ec
+set_var EASYRSA_CURVE sect571r1
+set_var EASYRSA_DIGEST "sha512"' > vars
 	# Create the PKI, set up the CA, the DH params and the server + client certificates
 	./easyrsa init-pki
 	./easyrsa --batch build-ca nopass
@@ -340,12 +341,12 @@ cert server.crt
 key server.key
 tls-crypt tls-crypt.key 0
 dh none
-ecdh-curve secp256k1 
-auth SHA256
-cipher AES-128-GCM
+ecdh-curve sect571r1 
+auth SHA512
+cipher AES-256-GCM
 tls-server
 tls-version-min 1.2
-tls-cipher TLS-ECDHE-ECDSA-WITH-AES-128-GCM-SHA256
+tls-cipher TLS-ECDHE-ECDSA-WITH-AES-256-GCM-SHA384
 status openvpn.log
 verb 3" >> /etc/openvpn/server.conf
 
@@ -458,11 +459,11 @@ nobind
 persist-key
 persist-tun
 remote-cert-tls server
-auth SHA256
-cipher AES-128-GCM
+auth SHA512
+cipher AES-256-GCM
 tls-client
 tls-version-min 1.2
-tls-cipher TLS-ECDHE-ECDSA-WITH-AES-128-GCM-SHA256
+tls-cipher TLS-ECDHE-ECDSA-WITH-AES-256-GCM-SHA384
 setenv opt block-outside-dns
 verb 3" >> /etc/openvpn/client-template.txt
 

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -406,7 +406,7 @@ cert server.crt
 key server.key
 tls-auth tls-auth.key 0
 dh none
-ecdh-curve
+ecdh-curve secp256k1 
 auth SHA256
 cipher cipher AES-128-GCM
 tls-server

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -403,7 +403,6 @@ WantedBy=multi-user.target" > /etc/systemd/system/rc-local.service
 	# Create the PKI, set up the CA, the DH params and the server + client certificates
 	./easyrsa init-pki
 	./easyrsa --batch build-ca nopass
-	openssl dhparam $DH_KEY_SIZE -out dh.pem
 	./easyrsa build-server-full server nopass
 	./easyrsa build-client-full $CLIENT nopass
 	./easyrsa gen-crl
@@ -461,7 +460,7 @@ ca ca.crt
 cert server.crt
 key server.key
 tls-auth tls-auth.key 0
-dh dh.pem
+dh none
 auth SHA256
 $CIPHER
 tls-server

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -344,7 +344,8 @@ WantedBy=multi-user.target" > /etc/systemd/system/rc-local.service
 	chown -R root:root /etc/openvpn/easy-rsa/
 	rm -rf ~/EasyRSA-3.0.1.tgz
 	cd /etc/openvpn/easy-rsa/
-	echo "set_var EASYRSA_KEY_SIZE $RSA_KEY_SIZE" > vars
+	echo "set_var EASYRSA_ALGO ec
+set_var EASYRSA_CURVE secp384r1" > vars
 	# Create the PKI, set up the CA, the DH params and the server + client certificates
 	./easyrsa init-pki
 	./easyrsa --batch build-ca nopass

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -350,8 +350,8 @@ status openvpn.log
 verb 3" >> /etc/openvpn/server.conf
 
 	# Create the sysctl configuration file if needed (mainly for Arch Linux)
-	if [[ ! -e $SYSCTL ]]; then
-		touch $SYSCTL
+	if [[ ! -e /etc/sysctl.conf ]]; then
+		touch /etc/sysctl.conf
 	fi
 
 	# Enable net.ipv4.ip_forward for the system

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -58,6 +58,7 @@ fi
 
 newclient () {
 	# Generates the custom client.ovpn
+	# We put everything in the client file
 	cp /etc/openvpn/client-template.txt ~/$1.ovpn
 	echo "<ca>" >> ~/$1.ovpn
 	cat /etc/openvpn/easy-rsa/pki/ca.crt >> ~/$1.ovpn
@@ -68,10 +69,9 @@ newclient () {
 	echo "<key>" >> ~/$1.ovpn
 	cat /etc/openvpn/easy-rsa/pki/private/$1.key >> ~/$1.ovpn
 	echo "</key>" >> ~/$1.ovpn
-	echo "key-direction 1" >> ~/$1.ovpn
-	echo "<tls-auth>" >> ~/$1.ovpn
-	cat /etc/openvpn/tls-auth.key >> ~/$1.ovpn
-	echo "</tls-auth>" >> ~/$1.ovpn
+	echo "<tls-crypt>" >> ~/$1.ovpn
+	cat /etc/openvpn/tls-crypt.key >> ~/$1.ovpn
+	echo "</tls-crypt>" >> ~/$1.ovpn
 }
 
 # Try to get our IP from the system and fallback to the Internet.
@@ -352,8 +352,8 @@ set_var EASYRSA_CURVE secp384r1" > vars
 	./easyrsa build-server-full server nopass
 	./easyrsa build-client-full $CLIENT nopass
 	./easyrsa gen-crl
-	# generate tls-auth key
-	openvpn --genkey --secret /etc/openvpn/tls-auth.key
+	# Generate tls-crypt key
+	openvpn --genkey --secret /etc/openvpn/tls-crypt.key
 	# Move all the generated files
 	cp pki/ca.crt pki/private/ca.key pki/issued/server.crt pki/private/server.key /etc/openvpn/easy-rsa/pki/crl.pem /etc/openvpn
 	# Make cert revocation list readable for non-root
@@ -405,7 +405,7 @@ echo "crl-verify crl.pem
 ca ca.crt
 cert server.crt
 key server.key
-tls-auth tls-auth.key 0
+tls-crypt tls-crypt.key 0
 dh none
 ecdh-curve secp256k1 
 auth SHA256

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -27,11 +27,12 @@ if [[ -e /etc/debian_version ]]; then
 	SYSCTL='/etc/sysctl.conf'
 	if [[ "$VERSION_ID" != 'VERSION_ID="7"' ]] && [[ "$VERSION_ID" != 'VERSION_ID="8"' ]] && [[ "$VERSION_ID" != 'VERSION_ID="12.04"' ]] && [[ "$VERSION_ID" != 'VERSION_ID="14.04"' ]] && [[ "$VERSION_ID" != 'VERSION_ID="16.04"' ]] && [[ "$VERSION_ID" != 'VERSION_ID="16.10"' ]]; then
 		echo "Your version of Debian/Ubuntu is not supported."
-		echo "I can't install a recent version of OpenVPN on your system."
+		echo "I can't install OpenVPN 2.4 on your system."
 		echo ""
 		echo "However, if you're using Debian unstable/testing, or Ubuntu beta,"
-		echo "then you can continue, a recent version of OpenVPN is available on these."
-		echo "Keep in mind they are not supported, though."
+		echo "then you can continue, this version of OpenVPN is available on these."
+		echo "Keep in mind these releases are not supported, though."
+		
 		while [[ $CONTINUE != "y" && $CONTINUE != "n" ]]; do
 			read -p "Continue ? [y/n]: " -e CONTINUE
 		done
@@ -309,30 +310,35 @@ else
 		# We add the OpenVPN repo to get the latest version.
 		# Debian 7
 		if [[ "$VERSION_ID" = 'VERSION_ID="7"' ]]; then
-			echo "deb http://swupdate.openvpn.net/apt wheezy main" > /etc/apt/sources.list.d/swupdate-openvpn.list
+			echo "deb http://build.openvpn.net/debian/openvpn/release/2.4 wheezy main" > /etc/apt/sources.list.d/openvpn.list
 			wget -O - https://swupdate.openvpn.net/repos/repo-public.gpg | apt-key add -
 			apt-get update
 		fi
 		# Debian 8
 		if [[ "$VERSION_ID" = 'VERSION_ID="8"' ]]; then
-			echo "deb http://swupdate.openvpn.net/apt jessie main" > /etc/apt/sources.list.d/swupdate-openvpn.list
+			echo "deb http://build.openvpn.net/debian/openvpn/release/2.4 jessie main" > /etc/apt/sources.list.d/openvpn.list
 			wget -O - https://swupdate.openvpn.net/repos/repo-public.gpg | apt-key add -
 			apt update
 		fi
 		# Ubuntu 12.04
 		if [[ "$VERSION_ID" = 'VERSION_ID="12.04"' ]]; then
-			echo "deb http://swupdate.openvpn.net/apt precise main" > /etc/apt/sources.list.d/swupdate-openvpn.list
+			echo "deb http://build.openvpn.net/debian/openvpn/release/2.4 precise main" > /etc/apt/sources.list.d/openvpn.list
 			wget -O - https://swupdate.openvpn.net/repos/repo-public.gpg | apt-key add -
 			apt-get update
 		fi
 		# Ubuntu 14.04
 		if [[ "$VERSION_ID" = 'VERSION_ID="14.04"' ]]; then
-			echo "deb http://swupdate.openvpn.net/apt trusty main" > /etc/apt/sources.list.d/swupdate-openvpn.list
+			echo "deb http://build.openvpn.net/debian/openvpn/release/2.4 trusty main" > /etc/apt/sources.list.d/openvpn.list
 			wget -O - https://swupdate.openvpn.net/repos/repo-public.gpg | apt-key add -
 			apt-get update
 		fi
-		# Ubuntu >= 16.04 and Debian > 8 have OpenVPN > 2.3.3 without the need of a third party repository.
-		# The we install OpenVPN
+		# Ubuntu 16.04
+		if [[ "$VERSION_ID" = 'VERSION_ID="16.04"' ]]; then
+			echo "deb http://build.openvpn.net/debian/openvpn/release/2.4 xenial main" > /etc/apt/sources.list.d/openvpn.list
+			wget -O - https://swupdate.openvpn.net/repos/repo-public.gpg | apt-key add -
+			apt-get update
+		fi
+		# Then we install OpenVPN
 		apt-get install openvpn iptables openssl wget ca-certificates curl -y
 	elif [[ "$OS" = 'centos' ]]; then
 		yum install epel-release -y

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -408,7 +408,7 @@ tls-auth tls-auth.key 0
 dh none
 ecdh-curve secp256k1 
 auth SHA256
-cipher cipher AES-128-GCM
+cipher AES-128-GCM
 tls-server
 tls-version-min 1.2
 tls-cipher TLS-ECDHE-ECDSA-WITH-AES-128-GCM-SHA256

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -221,9 +221,9 @@ else
 	echo "and are still viable to date, unlike some default OpenVPN options"
 	echo ''
 	echo "Choose which cipher you want to use for the data channel:"
-	echo "   1) AES-128-CBC (fastest and sufficiently secure for everyone, recommended)"
-	echo "   2) AES-192-CBC"
-	echo "   3) AES-256-CBC"
+	echo "   1) AES-128-GCM (fastest and sufficiently secure for everyone, recommended)"
+	echo "   2) AES-192-GCM"
+	echo "   3) AES-256-GCM"
 	echo "Alternatives to AES, use them only if you know what you're doing."
 	echo "They are relatively slower but as secure as AES."
 	echo "   4) CAMELLIA-128-CBC"
@@ -235,13 +235,13 @@ else
 	done
 	case $CIPHER in
 		1)
-		CIPHER="cipher AES-128-CBC"
+		CIPHER="cipher AES-128-GCM"
 		;;
 		2)
-		CIPHER="cipher AES-192-CBC"
+		CIPHER="cipher AES-192-GCM"
 		;;
 		3)
-		CIPHER="cipher AES-256-CBC"
+		CIPHER="cipher AES-256-GCM"
 		;;
 		4)
 		CIPHER="cipher CAMELLIA-128-CBC"

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -354,7 +354,7 @@ WantedBy=multi-user.target" > /etc/systemd/system/rc-local.service
 	# generate tls-auth key
 	openvpn --genkey --secret /etc/openvpn/tls-auth.key
 	# Move all the generated files
-	cp pki/ca.crt pki/private/ca.key dh.pem pki/issued/server.crt pki/private/server.key /etc/openvpn/easy-rsa/pki/crl.pem /etc/openvpn
+	cp pki/ca.crt pki/private/ca.key pki/issued/server.crt pki/private/server.key /etc/openvpn/easy-rsa/pki/crl.pem /etc/openvpn
 	# Make cert revocation list readable for non-root
 	chmod 644 /etc/openvpn/crl.pem
 	


### PR DESCRIPTION
As OpenVPN 2.4 is out, some improvements will be implemented to the script.

- [x] Use AES-GCM for the data channel's cipher instead of AES-CBC
- [x] Disable DH
- [x] Enable ECDH
- [x] Use an ECDSA certificate instead of RSA
- [x] [Use --tls-crypt instead of --tls-auth](https://community.openvpn.net/openvpn/changeset/c6e24fa3e16c32f9b427e360fd07102f613aa5c6/)
- [x] ~~[Update the Arch Linux installation ](https://www.archlinux.org/news/openvpn-240-update-requires-administrative-interaction/)~~ Remove Arch Linux support
- [x] Not related to the 2.4 update, but I want to use the best encryption settings everywhere (AES 256 GCM and SHA 512), thus I'll remove the choice for other ciphers, thus making the script more simple to use.
- [ ] Update the Readme

Also, we have to make sure that OpenVPN 2.4 is available everywhere.
- [x] Debian 7 (thanks to the [official OpenVPN repo](https://community.openvpn.net/openvpn/wiki/OpenvpnSoftwareRepos))
- [x] Debian 8 (thanks to the [official OpenVPN repo](https://community.openvpn.net/openvpn/wiki/OpenvpnSoftwareRepos))
- [x] Ubuntu 12.04 LTS (thanks to the [official OpenVPN repo](https://community.openvpn.net/openvpn/wiki/OpenvpnSoftwareRepos))
- [x] Ubuntu 14.04 LTS (thanks to the [official OpenVPN repo](https://community.openvpn.net/openvpn/wiki/OpenvpnSoftwareRepos))
- [x] Ubuntu 16.04 LTS (thanks to the [official OpenVPN repo](https://community.openvpn.net/openvpn/wiki/OpenvpnSoftwareRepos))
- [ ] Ubuntu 16.10
- [ ] CentOS 6
- [ ] CentOS 7
- [x] Arch Linux

Clients : 
- [x] Windows
- [x] MacOS (via [Homebrew](https://github.com/Homebrew/homebrew-core/blob/master/Formula/openvpn.rb) or [TunnelBlick](https://tunnelblick.net/))
- [ ] iOS
- [x] Android with [an alternative client](https://play.google.com/store/apps/details?id=it.colucciweb.free.openvpn)
-  For Linux clients, see above.