### PR TITLE
Slight crypto upgrade.

### DIFF
--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -466,7 +466,7 @@ auth SHA512
 $CIPHER
 tls-server
 tls-version-min 1.2
-tls-cipher TLS-DHE-RSA-WITH-AES-128-GCM-SHA256
+tls-cipher TLS-DHE-RSA-WITH-AES-256-GCM-SHA384
 status openvpn.log
 verb 3" >> /etc/openvpn/server.conf
 
@@ -583,7 +583,7 @@ auth SHA512
 $CIPHER
 tls-client
 tls-version-min 1.2
-tls-cipher TLS-DHE-RSA-WITH-AES-128-GCM-SHA256
+tls-cipher TLS-DHE-RSA-WITH-AES-256-GCM-SHA512
 setenv opt block-outside-dns
 verb 3" >> /etc/openvpn/client-template.txt
 

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -462,7 +462,7 @@ cert server.crt
 key server.key
 tls-auth tls-auth.key 0
 dh dh.pem
-auth SHA256
+auth SHA512
 $CIPHER
 tls-server
 tls-version-min 1.2
@@ -579,7 +579,7 @@ nobind
 persist-key
 persist-tun
 remote-cert-tls server
-auth SHA256
+auth SHA512
 $CIPHER
 tls-client
 tls-version-min 1.2


### PR DESCRIPTION
SHA384 and SHA512 take roughly the same amount of time to run as SHA256. 

AES-256 vs AES-128 may actually impact performance, but I'm always in favor of picking the most hardcore options.