### PR TITLE
Will now set "local" in server.conf to the chosen IP adderess

### DIFF
--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -428,7 +428,7 @@ WantedBy=multi-user.target" > /etc/systemd/system/rc-local.service
 
 	# Generate server.conf
 	echo "local $IP" > /etc/openvpn/server.conf
-	echo "port $PORT" > /etc/openvpn/server.conf
+	echo "port $PORT" >> /etc/openvpn/server.conf
 	if [[ "$PROTOCOL" = 'UDP' ]]; then
 		echo "proto udp" >> /etc/openvpn/server.conf
 	elif [[ "$PROTOCOL" = 'TCP' ]]; then

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -427,6 +427,7 @@ WantedBy=multi-user.target" > /etc/systemd/system/rc-local.service
 	chmod 644 /etc/openvpn/crl.pem
 
 	# Generate server.conf
+	echo "local $IP" > /etc/openvpn/server.conf
 	echo "port $PORT" > /etc/openvpn/server.conf
 	if [[ "$PROTOCOL" = 'UDP' ]]; then
 		echo "proto udp" >> /etc/openvpn/server.conf


### PR DESCRIPTION
If you want to run OpenVPN in UDP mode on an secondary IP, UDP routing will fail unless you explicitly bind OpenVPN to the chosen IP address. This change includes the "local" parameter in the config and sets it to the IP address entered at the beginning.