### PR TITLE
OpenVPN 2.4 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,15 +53,18 @@ On the client-side, it's less problematic, but if you want to use an OpenVPN ser
 ## Compatibility
 
 |              | i386   |  amd64 | armhf   | arm64 |
-| ------------ | ------ | ------ | ------- | -------|
-|   Debian 8   |   ✔️  |   ✔️   |   ❌   |   ❌   |
-|   Debian 9   |   ✔️  |   ✔️   |   ✔️   |   ✔️   |
-| Ubuntu 14.04 |   ✔️  |   ✔️   |   ❌   |   ❌   |
-| Ubuntu 16.04 |   ✔️  |   ✔️   |   ❌   |   ❌   |
-| Ubuntu 17.04 |   ✔️  |   ✔️   |   ✔️   |   ✔️   |
+| ------------ | ------ | ------ | ------- | ------|
+|   Debian 8   |   ✔️  |   ✔️   |   ❌   |   ❌  |
+|   Debian 9   |   ✔️  |   ✔️   |   ✔️   |   ✔️  |
+| Ubuntu 14.04 |   ✔️  |   ✔️   |   ❌   |   ❌  |
+| Ubuntu 16.04 |   ✔️  |   ✔️   |   ❌   |   ❌  |
+| Ubuntu 17.04 |   ✔️  |   ✔️   |   ✔️   |   ✔️  |
 | [Ubuntu 17.10](https://github.com/Angristan/OpenVPN-install/issues/125) |   ❌  |   ❌   |   ❌   |   ❌   |
-|   CentOS 6   |   ✔️  |   ✔️   |   ❔   |   ❔   |
-|   CentOS 7   |   ✔️  |   ✔️   |   ✔️   |   ❔    |
+|   CentOS 6   |   ✔️  |   ✔️   |   ❔   |   ❔    |
+|   CentOS 7   |   ✔️  |   ✔️   |   ✔️  |   ❔    |
+|   Fedora 25  |   ❔   |   ✔️   |   ❔   |   ❔   |
+|   Fedora 26  |   ❔   |   ✔️   |   ❔   |   ❔   |
+|   Fedora 27  |   ❔   |   ✔️   |   ❔   |   ❔   |
 |  Arch Linux  |   ✔️  |   ✔️   |   ❔   |   ❌[(❔)](https://github.com/Angristan/OpenVPN-install/issues/99)   |
 
 - ✔️ = tested and compatible

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ This fork includes the following features :
 - No comp-lzo, as [compression is a vector for oracle attacks, e.g. CRIME or BREACH](https://github.com/BetterCrypto/Applied-Crypto-Hardening/pull/91#issuecomment-75388575)
 - [Arch Linux support](https://github.com/Angristan/OpenVPN-install/pull/2)
 - Up-to-date OpenVPN thanks to [EPEL](http://fedoraproject.org/wiki/EPEL) for CentOS and [swupdate.openvpn.net](https://community.openvpn.net/openvpn/wiki/OpenvpnSoftwareRepos) for Ubuntu and Debian. These are third-party yet trusted repositories.
+- Randomized certificate name
 - Other improvements !
 
 ## DNS

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Here is a preview of the installer :
 
 **You have to enable the TUN module otherwise OpenVPN won't work.** Ask your host if you don't know how to do it. If the TUN module is not enabled, the script will warn you and exit.
 
-You can get a cheap VPS to run this script for $2.50/month worldwide at [Vultr](https://goo.gl/Xyd1Sc) or 3€/month for unlimited bandwidth in France at [PulseHeberg](https://goo.gl/76yqW5).
+You can get a cheap VPS to run this script at [Vultr](https://goo.gl/Xyd1Sc), [Digital Ocean](https://goo.gl/qXrNLK) or [PulseHeberg](https://goo.gl/76yqW5).
 
 First, get the script and make it executable :
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ On the client-side, it's less problematic, but if you want to use an OpenVPN ser
 |   Fedora 25  |   ❔   |   ✔️   |   ❔   |   ❔   |
 |   Fedora 26  |   ❔   |   ✔️   |   ❔   |   ❔   |
 |   Fedora 27  |   ❔   |   ✔️   |   ❔   |   ❔   |
-|  Arch Linux  |   ✔️  |   ✔️   |   ❔   |   ❌[(❔)](https://github.com/Angristan/OpenVPN-install/issues/99)   |
+|  Arch Linux  |   ✔️  |   ✔️   |   ❌[(❔)](https://github.com/Angristan/OpenVPN-install/issues/99)   |   ✔️   |
 
 - ✔️ = tested and compatible
 

--- a/README.md
+++ b/README.md
@@ -52,15 +52,16 @@ On the client-side, it's less problematic, but if you want to use an OpenVPN ser
 
 ## Compatibility
 
-|              | i386 | amd64 | armhf | arm64 |
-|:------------:|:----:|:-----:|:-----:|:-----:|
+|              | i386   |  amd64 | armhf   | arm64 |
+| ------------ | ------ | ------ | ------- | -------|
 |   Debian 8   |   ✔️  |   ✔️   |   ❌   |   ❌   |
 |   Debian 9   |   ✔️  |   ✔️   |   ✔️   |   ✔️   |
 | Ubuntu 14.04 |   ✔️  |   ✔️   |   ❌   |   ❌   |
 | Ubuntu 16.04 |   ✔️  |   ✔️   |   ❌   |   ❌   |
 | Ubuntu 17.04 |   ✔️  |   ✔️   |   ✔️   |   ✔️   |
+| [Ubuntu 17.10](https://github.com/Angristan/OpenVPN-install/issues/125) |   ❌  |   ❌   |   ❌   |   ❌   |
 |   CentOS 6   |   ✔️  |   ✔️   |   ❔   |   ❔   |
-|   CentOS 7   |   ✔️  |   ✔️   |   ✔️   |   ❔   |
+|   CentOS 7   |   ✔️  |   ✔️   |   ✔️   |   ❔    |
 |  Arch Linux  |   ✔️  |   ✔️   |   ❔   |   ❌[(❔)](https://github.com/Angristan/OpenVPN-install/issues/99)   |
 
 - ✔️ = tested and compatible

--- a/README.md
+++ b/README.md
@@ -50,18 +50,22 @@ On the client-side, it's less problematic, but if you want to use an OpenVPN ser
 
 ## Compatibility
 
-The script is made to work on these OS and architectures :
-- **Debian 7** (i386, amd64)
-- **Debian 8** (i386, amd64)
-- **Debian 9** (i386, amd64, armhf, arm64)
-- **Ubuntu 12.04 LTS** (i386, amd64)
-- **Ubuntu 14.04 LTS** (i386, amd64)
-- **Ubuntu 16.04 LTS** (i386, amd64)
-- **Ubuntu 16.10** (i386, amd64, armhf, arm64)
-- **Ubuntu 17.04** (i386, amd64, armhf, arm64)
-- **CentOS 6** (i386, amd64)
-- **CentOS 7** (i386, amd64, arm64)
-- **Arch Linux** (i686, amd64)
+|              | i386 | amd64 | armhf | arm64 |
+|:------------:|:----:|:-----:|:-----:|:-----:|
+|   Debian 8   |   ✔️  |   ✔️   |   ❌   |   ❌   |
+|   Debian 9   |   ✔️  |   ✔️   |   ✔️   |   ✔️   |
+| Ubuntu 14.04 |   ✔️  |   ✔️   |   ❌   |   ❌   |
+| Ubuntu 16.04 |   ✔️  |   ✔️   |   ❌   |   ❌   |
+| Ubuntu 17.04 |   ✔️  |   ✔️   |   ✔️   |   ✔️   |
+|   CentOS 6   |   ✔️  |   ✔️   |   ❔   |   ❔   |
+|   CentOS 7   |   ✔️  |   ✔️   |   ✔️   |   ❔   |
+|  Arch Linux  |   ✔️  |   ✔️   |   ❔   |   ❌[(❔)](https://github.com/Angristan/OpenVPN-install/issues/99)   |
+
+- ✔️ = tested and compatible
+
+- ❔ = untested
+
+- ❌ = tested and not compatible
 
 (It should also work on Debian unstable/testing and Ubuntu beta).
 

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -428,8 +428,8 @@ else
 	echo "   1) SHA-256"
 	echo "   2) SHA-384 (recommended)"
 	echo "   3) SHA-512"
-		while [[ $HMAC_AUTH != "1" && $HMAC_AUTH != "2" ]]; do
-			read -p "HMAC authentication algorithmHMAC_AUTH [1-3]: " -e -i 2 HMAC_AUTH
+		while [[ $HMAC_AUTH != "1" && $HMAC_AUTH != "2" && $HMAC_AUTH != "3" ]]; do
+			read -p "HMAC authentication algorithm [1-3]: " -e -i 2 HMAC_AUTH
 	done
 	case $HMAC_AUTH in
 		1)

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -517,7 +517,6 @@ else
 		elif [[ "$VERSION_ID" = 'VERSION_ID="9"' ]]; then
 			echo "deb http://build.openvpn.net/debian/openvpn/stable stretch main" > /etc/apt/sources.list.d/openvpn.list
 			wget -O - https://swupdate.openvpn.net/repos/repo-public.gpg | apt-key add -
-		fi
 		# Ubuntu 14.04
 		elif [[ "$VERSION_ID" = 'VERSION_ID="14.04"' ]]; then
 			echo "deb http://build.openvpn.net/debian/openvpn/stable trusty main" > /etc/apt/sources.list.d/openvpn.list

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -439,13 +439,13 @@ else
 	done
 	case $HMAC_AUTH in
 		1)
-			HMAC_AUTH="sha256"
+			HMAC_AUTH="SHA256"
 		;;
 		2)
-			HMAC_AUTH="sha384"
+			HMAC_AUTH="SHA384"
 		;;
 		3)
-			HMAC_AUTH="sha512"
+			HMAC_AUTH="SHA512"
 		;;
 	esac
 	echo "tls crypt or tls auth"

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -78,9 +78,9 @@ newclient () {
 	#We verify if we used tls-crypt or tls-auth during the installation
 	TLS_SIG=$(cat /etc/openvpn/TLS_SIG)
 	if [[ $TLS_SIG == "1" ]]; then
-		echo "<tls-crypt>" >> ~/$1.ovpn
-		cat /etc/openvpn/tls-crypt.key >> ~/$1.ovpn
-		echo "</tls-crypt>" >> ~/$1.ovpn
+		echo "<tls-crypt>" >> $homeDir/$1.ovpn
+		cat /etc/openvpn/tls-crypt.key >> $homeDir/$1.ovpn
+		echo "</tls-crypt>" >> $homeDir/$1.ovpn
 	elif [[ $TLS_SIG == "2" ]]; then
 		echo "key-direction 1" >> $homeDir/$1.ovpn
 		echo "<tls-auth>" >> $homeDir/$1.ovpn

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -380,7 +380,7 @@ else
 	echo "   1) SHA-256"
 	echo "   2) SHA-384 (recommended)"
 	echo "   3) SHA-512"
-	while [[ $CERT_HASH != "1" && $CERT_HASH != "2" ]]; do
+	while [[ $CERT_HASH != "1" && $CERT_HASH != "2" && $CERT_HASH != "3"]]; do
 		read -p "Cert hash algo [1-3]: " -e -i 2 CERT_HASH
 	done
 	case $CERT_HASH in

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -238,10 +238,12 @@ else
 	done
 	echo ""
 	echo "See https://github.com/Angristan/OpenVPN-install#encryption to learn more about "
-	echo "the encryption in OpenVPN and the choices I made in this script."
-	echo "Please note that all the choices proposed are secure enough considering today's strandards,"
-	echo "unlike some default OpenVPN options"
-	echo ''
+	echo "the encryption in OpenVPN and the choices proposed in this script."
+	echo "Please note that all the choices proposed are secure enough considering today's strandards, unlike some default OpenVPN options"
+	echo "You can just type "enter" if you don't know what to choose."
+	echo "Note that if you want to use an OpenVPN 2.3 client, You'll have to choose OpenVPN 2.3-compatible options."
+	echo "All OpenVPN 2.3-compatible choices are specified for each following option."
+	echo ""
 	echo "Choose which cipher you want to use for the data channel:"
 	echo "   1) AES-128-GCM (recommended)"
 	echo "   2) AES-192-GCM"
@@ -251,7 +253,7 @@ else
 	echo "   5) AES-192-CBC"
 	echo "   6) AES-256-CBC"
 	while [[ $CIPHER != "1" && $CIPHER != "2" && $CIPHER != "3" && $CIPHER != "4" && $CIPHER != "5" && $CIPHER != "6" ]]; do
-		read -p "Cipher [1-7]: " -e -i 1 CIPHER
+		read -p "Data channel cipher [1-6]: " -e -i 1 CIPHER
 	done
 	case $CIPHER in
 		1)
@@ -274,76 +276,23 @@ else
 		;;
 	esac
 	echo ""
-	echo "Choose what kind of Diffie-Hellman key you want to use."
-	echo "Elleptic Curves (EC) are recommended, they're faster, lighter and more secure."
-	echo "Use DH for OpenVPN 2.3 compatibilty"
-	echo "   1) ECDH (recommended)"
-	echo "   2) DH"
-	while [[ $DH_TYPE != "1" && $DH_TYPE != "2" ]]; do
-		read -p "DH key size [1-2]: " -e -i 1 DH_TYPE
-	done
-	case $DH_TYPE in
-		1)
-			echo ""
-			echo "Choose which curve you want to use"
-			echo "   1) secp256r1"
-			echo "   2) secp384r1 (recommended)"
-			echo "   3) secp521r1"
-			while [[ $DH_CURVE != "1" && $DH_CURVE != "2" && $DH_CURVE != "3" ]]; do
-				read -p "ECDH [1-3]: " -e -i 2 DH_CURVE
-			done
-			case $DH_CURVE in
-				1)
-					DH_CURVE="secp256r1"
-				;;
-				2)
-					DH_CURVE="secp384r1"
-				;;
-				3)
-					DH_CURVE="secp521r1"
-				;;
-			esac
-		;;
-		2)
-			echo""
-			echo "Choose which DH key size do you want to use"
-			echo "   1) 2048 bits"
-			echo "   2) 3072 bits (recommended)"
-			echo "   3) 4096 bits"
-			while [[ $DH_SIZE != "1" && $DH_SIZE != "2" && $DH_SIZE != "3" ]]; do
-				read -p "DH key size [1-3]: " -e -i 2 DH_SIZE
-			done
-			case $DH_SIZE in
-				1)
-					DH_SIZE="2048"
-				;;
-				2)
-					DH_SIZE="3072"
-				;;
-				3)
-					DH_SIZE="4096"
-				;;
-			esac
-		;;
-	esac
-	echo ""
-	echo "Choose what kind Certificate key you want to use."
-	echo "Elleptic Curves (EC) are recommended, they're faster, lighter and more secure."
+	echo "Choose what kind of certificate you want to use:"
+	echo "Elleptic Curves keys (EC) are recommended, they're faster, lighter and more secure."
 	echo "Use RSA for OpenVPN 2.3 compatibilty"
 	echo "   1) ECDSA (recommended)"
 	echo "   2) RSA"
 	while [[ $CERT_TYPE != "1" && $CERT_TYPE != "2" ]]; do
-		read -p "Certificate key [1-2]: " -e -i 1 CERT_TYPE
+		read -p "Certificate type [1-2]: " -e -i 1 CERT_TYPE
 	done
 	case $CERT_TYPE in
 		1)
 			echo ""
-			echo "Choose which curve you want to use:"
+			echo "Choose which curve you want to use for the EC key:"
 			echo "   1) secp256r1"
 			echo "   2) secp384r1 (recommended)"
 			echo "   3) secp521r1"
 			while [[ $CERT_CURVE != "1" && $CERT_CURVE != "2" && $CERT_CURVE != "3" ]]; do
-				read -p "ECDH [1-3]: " -e -i 2 CERT_CURVE
+				read -p "Curve [1-3]: " -e -i 2 CERT_CURVE
 			done
 			case $CERT_CURVE in
 				1)
@@ -359,7 +308,7 @@ else
 		;;
 		2)
 			echo ""
-			echo "Choose which RSA key size do you want to use:"
+			echo "Choose which RSA key size you want to use:"
 			echo "   1) 2048 bits"
 			echo "   2) 3072 bits (recommended)"
 			echo "   3) 4096 bits"
@@ -385,7 +334,7 @@ else
 	echo "   2) SHA-384 (recommended)"
 	echo "   3) SHA-512"
 	while [[ $CERT_HASH != "1" && $CERT_HASH != "2" && $CERT_HASH != "3" ]]; do
-		read -p "Cert hash algo [1-3]: " -e -i 2 CERT_HASH
+		read -p "Hash algorithm [1-3]: " -e -i 2 CERT_HASH
 	done
 	case $CERT_HASH in
 		1)
@@ -399,12 +348,65 @@ else
 		;;
 	esac
 	echo ""
-	echo "Which cipher to use for the control channel ?"
+	echo "Choose what kind of Diffie-Hellman key you want to use."
+	echo "Elleptic Curves (EC) are recommended, they're faster, lighter and more secure."
+	echo "Use DH for OpenVPN 2.3 compatibilty"
+	echo "   1) ECDH (recommended)"
+	echo "   2) DH"
+	while [[ $DH_TYPE != "1" && $DH_TYPE != "2" ]]; do
+		read -p "DH key type [1-2]: " -e -i 1 DH_TYPE
+	done
+	case $DH_TYPE in
+		1)
+			echo ""
+			echo "Choose which curve you want to use for the ECDH key"
+			echo "   1) secp256r1"
+			echo "   2) secp384r1 (recommended)"
+			echo "   3) secp521r1"
+			while [[ $DH_CURVE != "1" && $DH_CURVE != "2" && $DH_CURVE != "3" ]]; do
+				read -p "Curve [1-3]: " -e -i 2 DH_CURVE
+			done
+			case $DH_CURVE in
+				1)
+					DH_CURVE="secp256r1"
+				;;
+				2)
+					DH_CURVE="secp384r1"
+				;;
+				3)
+					DH_CURVE="secp521r1"
+				;;
+			esac
+		;;
+		2)
+			echo""
+			echo "Choose which DH key size you want to use"
+			echo "   1) 2048 bits"
+			echo "   2) 3072 bits (recommended)"
+			echo "   3) 4096 bits"
+			while [[ $DH_SIZE != "1" && $DH_SIZE != "2" && $DH_SIZE != "3" ]]; do
+				read -p "DH key size [1-3]: " -e -i 2 DH_SIZE
+			done
+			case $DH_SIZE in
+				1)
+					DH_SIZE="2048"
+				;;
+				2)
+					DH_SIZE="3072"
+				;;
+				3)
+					DH_SIZE="4096"
+				;;
+			esac
+		;;
+	esac
+	echo ""
+	echo "Choose which cipher you want to use for the control channel:"
 	if [[ "$CERT_TYPE" = '1' ]]; then
 		echo "   1) ECDHE-ECDSA-AES-256-GCM-SHA384 (recommended)"
 		echo "   2) ECDHE-ECDSA-AES-128-GCM-SHA256"
 		while [[ $CC_ENC != "1" && $CC_ENC != "2" ]]; do
-			read -p "Control Channel encryption [1-2]: " -e -i 1 CC_ENC
+			read -p "Control channel cipher [1-2]: " -e -i 1 CC_ENC
 		done
 		case $CC_ENC in
 			1)
@@ -418,7 +420,7 @@ else
 		echo "   1) ECDHE-RSA-AES-256-GCM-SHA384 (recommended)"
 		echo "   2) ECDHE-RSA-AES-128-GCM-SHA256"
 		while [[ $CC_ENC != "1" && $CC_ENC != "2" ]]; do
-			read -p "Control Channel encryption [1-2]: " -e -i 1 CC_ENC
+			read -p "Control channel cipher [1-2]: " -e -i 1 CC_ENC
 		done
 		case $CC_ENC in
 			1)
@@ -429,6 +431,15 @@ else
 			;;
 		esac
 	fi
+	echo ""
+	echo "Do you want to use tls-crypt or tls-auth?"
+	echo "They both encrypt and authenticate all control channel packets with a key."
+	echo "tls-crypt is more advanced and secure than tls-auth, but it's an OpenVPN 2.4 feature."
+	echo "   1) tls-crypt (recommended)"
+	echo "   2) tls-auth (use only for OpenVPN 2.3 client compatibility)"
+	while [[ $TLS_SIG != "1" && $TLS_SIG != "2" ]]; do
+			read -p "Crontrol channel additional security layer [1-2]: " -e -i 1 TLS_SIG
+	done
 	echo""
 	if [[ $CIPHER = "cipher AES-256-GCM" ]] || [[ $CIPHER = "cipher AES-192-GCM" ]] || [[ $CIPHER = "cipher AES-128-GCM" ]]; then
 		echo "Choose which message digest algorithm you want to use for the tls-auth/tls-crypt control channel packets:"
@@ -453,13 +464,6 @@ else
 			HMAC_AUTH="SHA512"
 		;;
 	esac
-	echo ""
-	echo "tls crypt or tls auth"
-	echo "   1) tls-crypt (recommended)"
-	echo "   2) tls-auth (use only for openvpn 2.3 compat)"
-	while [[ $TLS_SIG != "1" && $TLS_SIG != "2" ]]; do
-			read -p "tls sig [1-2]: " -e -i 1 TLS_SIG
-	done
 	echo ""
 	echo "Finally, tell me a name for the client certificate and configuration"
 	while [[ $CLIENT = "" ]]; do

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -244,7 +244,7 @@ else
 	echo ""
 	echo "Choose which compression algorithm you want to use:"
 	echo "   1) LZ4 (faster)"
-	echo "   2) LZ0 (use for OpenVPN 2.3 compatibility"
+	echo "   2) LZ0 (use for OpenVPN 2.3 compatibility)"
 	while [[ $COMPRESSION != "1" && $COMPRESSION != "2" ]]; do
 		read -p "Compression algorithm [1-2]: " -e -i 1 COMPRESSION
 	done

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -514,6 +514,9 @@ else
 		if [[ "$VERSION_ID" = 'VERSION_ID="8"' ]]; then
 			echo "deb http://build.openvpn.net/debian/openvpn/stable jessie main" > /etc/apt/sources.list.d/openvpn.list
 			wget -O - https://swupdate.openvpn.net/repos/repo-public.gpg | apt-key add -
+		elif [[ "$VERSION_ID" = 'VERSION_ID="9"' ]]; then
+			echo "deb http://build.openvpn.net/debian/openvpn/stable stretch main" > /etc/apt/sources.list.d/openvpn.list
+			wget -O - https://swupdate.openvpn.net/repos/repo-public.gpg | apt-key add -
 		# Ubuntu 14.04
 		elif [[ "$VERSION_ID" = 'VERSION_ID="14.04"' ]]; then
 			echo "deb http://build.openvpn.net/debian/openvpn/stable trusty main" > /etc/apt/sources.list.d/openvpn.list

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -380,7 +380,7 @@ else
 	echo "   1) SHA-256"
 	echo "   2) SHA-384 (recommended)"
 	echo "   3) SHA-512"
-	while [[ $CERT_HASH != "1" && $CERT_HASH != "2" && $CERT_HASH != "3"]]; do
+	while [[ $CERT_HASH != "1" && $CERT_HASH != "2" && $CERT_HASH != "3" ]]; do
 		read -p "Cert hash algo [1-3]: " -e -i 2 CERT_HASH
 	done
 	case $CERT_HASH in

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -640,7 +640,7 @@ ca ca.crt
 cert server.crt
 key server.key" >> /etc/openvpn/server.conf
 if [[ $TLS_SIG == "1" ]]; then
-	echo "tls-auth tls-crypt.key 0" >> /etc/openvpn/server.conf
+	echo "tls-crypt tls-crypt.key 0" >> /etc/openvpn/server.conf
 elif [[ $TLS_SIG == "2" ]]; then
 	echo "tls-auth tls-auth.key 0" >> /etc/openvpn/server.conf
 fi

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -658,6 +658,7 @@ elif [[ $DH_TYPE == "2" ]]; then
 fi
 echo "auth $HMAC_AUTH
 $CIPHER
+ncp-disable
 tls-server
 tls-version-min 1.2
 tls-cipher $CC_ENC

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -471,27 +471,30 @@ else
 			echo "deb http://build.openvpn.net/debian/openvpn/stable wheezy main" > /etc/apt/sources.list.d/openvpn.list
 			wget -O - https://swupdate.openvpn.net/repos/repo-public.gpg | apt-key add -
 			apt-get update
-		fi
 		# Debian 8
-		if [[ "$VERSION_ID" = 'VERSION_ID="8"' ]]; then
+		elif [[ "$VERSION_ID" = 'VERSION_ID="8"' ]]; then
 			echo "deb http://build.openvpn.net/debian/openvpn/stable jessie main" > /etc/apt/sources.list.d/openvpn.list
 			wget -O - https://swupdate.openvpn.net/repos/repo-public.gpg | apt-key add -
 			apt update
-		fi
 		# Ubuntu 12.04
-		if [[ "$VERSION_ID" = 'VERSION_ID="12.04"' ]]; then
+		elif [[ "$VERSION_ID" = 'VERSION_ID="12.04"' ]]; then
 			echo "deb http://build.openvpn.net/debian/openvpn/stable precise main" > /etc/apt/sources.list.d/openvpn.list
 			wget -O - https://swupdate.openvpn.net/repos/repo-public.gpg | apt-key add -
 			apt-get update
-		fi
 		# Ubuntu 14.04
-		if [[ "$VERSION_ID" = 'VERSION_ID="14.04"' ]]; then
+		elif [[ "$VERSION_ID" = 'VERSION_ID="14.04"' ]]; then
 			echo "deb http://build.openvpn.net/debian/openvpn/stable trusty main" > /etc/apt/sources.list.d/openvpn.list
 			wget -O - https://swupdate.openvpn.net/repos/repo-public.gpg | apt-key add -
 			apt-get update
+		# Ubuntu 16.04
+		elif [[ "$VERSION_ID" = 'VERSION_ID="16.04"' ]]; then
+			echo "deb http://build.openvpn.net/debian/openvpn/stable xenial main" > /etc/apt/sources.list.d/openvpn.list
+			wget -O - https://swupdate.openvpn.net/repos/repo-public.gpg | apt-key add -
+			apt-get update
 		fi
-		# Ubuntu >= 16.04 and Debian > 8 have OpenVPN > 2.3.3 without the need of a third party repository.
+		# Ubuntu >= 17.04 and Debian > 9 have OpenVPN 2.4 without the need of a third party repository.
 		# The we install OpenVPN
+		apt-get update
 		apt-get install openvpn iptables openssl wget ca-certificates curl -y
 	elif [[ "$OS" = 'centos' ]]; then
 		yum install epel-release -y

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -25,7 +25,7 @@ if [[ -e /etc/debian_version ]]; then
 	VERSION_ID=$(cat /etc/os-release | grep "VERSION_ID")
 	RCLOCAL='/etc/rc.local'
 	SYSCTL='/etc/sysctl.conf'
-	if [[ "$VERSION_ID" != 'VERSION_ID="7"' ]] && [[ "$VERSION_ID" != 'VERSION_ID="8"' ]] && [[ "$VERSION_ID" != 'VERSION_ID="9"' ]] && [[ "$VERSION_ID" != 'VERSION_ID="12.04"' ]] && [[ "$VERSION_ID" != 'VERSION_ID="14.04"' ]] && [[ "$VERSION_ID" != 'VERSION_ID="16.04"' ]] && [[ "$VERSION_ID" != 'VERSION_ID="17.04"' ]]; then
+	if [[ "$VERSION_ID" != 'VERSION_ID="8"' ]] && [[ "$VERSION_ID" != 'VERSION_ID="9"' ]] && [[ "$VERSION_ID" != 'VERSION_ID="14.04"' ]] && [[ "$VERSION_ID" != 'VERSION_ID="16.04"' ]] && [[ "$VERSION_ID" != 'VERSION_ID="17.04"' ]]; then
 		echo "Your version of Debian/Ubuntu is not supported."
 		echo "I can't install a recent version of OpenVPN on your system."
 		echo ""
@@ -477,21 +477,11 @@ else
 	if [[ "$OS" = 'debian' ]]; then
 		apt-get install ca-certificates -y
 		# We add the OpenVPN repo to get the latest version.
-		# Debian 7
-		if [[ "$VERSION_ID" = 'VERSION_ID="7"' ]]; then
-			echo "deb http://build.openvpn.net/debian/openvpn/stable wheezy main" > /etc/apt/sources.list.d/openvpn.list
-			wget -O - https://swupdate.openvpn.net/repos/repo-public.gpg | apt-key add -
-			apt-get update
 		# Debian 8
 		elif [[ "$VERSION_ID" = 'VERSION_ID="8"' ]]; then
 			echo "deb http://build.openvpn.net/debian/openvpn/stable jessie main" > /etc/apt/sources.list.d/openvpn.list
 			wget -O - https://swupdate.openvpn.net/repos/repo-public.gpg | apt-key add -
 			apt update
-		# Ubuntu 12.04
-		elif [[ "$VERSION_ID" = 'VERSION_ID="12.04"' ]]; then
-			echo "deb http://build.openvpn.net/debian/openvpn/stable precise main" > /etc/apt/sources.list.d/openvpn.list
-			wget -O - https://swupdate.openvpn.net/repos/repo-public.gpg | apt-key add -
-			apt-get update
 		# Ubuntu 14.04
 		elif [[ "$VERSION_ID" = 'VERSION_ID="14.04"' ]]; then
 			echo "deb http://build.openvpn.net/debian/openvpn/stable trusty main" > /etc/apt/sources.list.d/openvpn.list

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -598,7 +598,7 @@ set_var EASYRSA_CURVE $CERT_CURVE" > vars
 	chmod 644 /etc/openvpn/crl.pem
 
 	# Generate server.conf
-	echo "port $PORT" >> /etc/openvpn/server.conf
+	echo "port $PORT" > /etc/openvpn/server.conf
 	if [[ "$PROTOCOL" = '1' ]]; then
 		echo "proto udp" >> /etc/openvpn/server.conf
 	elif [[ "$PROTOCOL" = '2' ]]; then

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -22,7 +22,7 @@ fi
 if [[ -e /etc/debian_version ]]; then
 	OS="debian"
 	# Getting the version number, to verify that a recent version of OpenVPN is available
-	VERSION_ID=$(cat /etc/os-release | grep "VERSION_ID")
+	VERSION_ID=$(grep "VERSION_ID" /etc/os-release)
 	IPTABLES='/etc/iptables/iptables.rules'
 	SYSCTL='/etc/sysctl.conf'
 	if [[ "$VERSION_ID" != 'VERSION_ID="8"' ]] && [[ "$VERSION_ID" != 'VERSION_ID="9"' ]] && [[ "$VERSION_ID" != 'VERSION_ID="14.04"' ]] && [[ "$VERSION_ID" != 'VERSION_ID="16.04"' ]] && [[ "$VERSION_ID" != 'VERSION_ID="17.10"' ]]; then

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -300,7 +300,7 @@ else
 					DH_CURVE="secp384r1"
 				;;
 				3)
-					DH_CURVE"secp521r1"
+					DH_CURVE="secp521r1"
 				;;
 			esac
 		;;
@@ -320,7 +320,7 @@ else
 					DH_SIZE="3072"
 				;;
 				3)
-					DH_SIZE"4096"
+					DH_SIZE="4096"
 				;;
 			esac
 		;;
@@ -351,7 +351,7 @@ else
 					CERT_CURVE="secp384r1"
 				;;
 				3)
-					CERT_CURVE"secp521r1"
+					CERT_CURVE="secp521r1"
 				;;
 			esac
 		;;
@@ -371,7 +371,7 @@ else
 					RSA_SIZE="3072"
 				;;
 				3)
-					RSA_SIZE"4096"
+					RSA_SIZE="4096"
 				;;
 			esac
 		;;

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -496,17 +496,14 @@ else
 		if [[ "$VERSION_ID" = 'VERSION_ID="8"' ]]; then
 			echo "deb http://build.openvpn.net/debian/openvpn/stable jessie main" > /etc/apt/sources.list.d/openvpn.list
 			wget -O - https://swupdate.openvpn.net/repos/repo-public.gpg | apt-key add -
-			apt update
 		# Ubuntu 14.04
 		elif [[ "$VERSION_ID" = 'VERSION_ID="14.04"' ]]; then
 			echo "deb http://build.openvpn.net/debian/openvpn/stable trusty main" > /etc/apt/sources.list.d/openvpn.list
 			wget -O - https://swupdate.openvpn.net/repos/repo-public.gpg | apt-key add -
-			apt-get update
 		# Ubuntu 16.04
 		elif [[ "$VERSION_ID" = 'VERSION_ID="16.04"' ]]; then
 			echo "deb http://build.openvpn.net/debian/openvpn/stable xenial main" > /etc/apt/sources.list.d/openvpn.list
 			wget -O - https://swupdate.openvpn.net/repos/repo-public.gpg | apt-key add -
-			apt-get update
 		fi
 		# Ubuntu >= 17.04 and Debian > 9 have OpenVPN 2.4 without the need of a third party repository.
 		# The we install OpenVPN

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -424,10 +424,9 @@ else
 			;;
 		esac
 	fi
-	if [[ $CIPHER != "1" && $CIPHER != "2" && $CIPHER != "3" ]]; then
+	if [[ $CIPHER = "1" && $CIPHER = "2" && $CIPHER = "3" ]]; then
 		echo "Choose which message digest algorithm you want to use for the tls-auth/tls-crypt control channel packets:"
-	fi
-	if [[ $CIPHER != "4" && $CIPHER != "5" && $CIPHER != "6" ]]; then
+	elif [[ $CIPHER = "4" && $CIPHER = "5" && $CIPHER = "6" ]]; then
 		echo "Choose which message digest algorithm you want to use for the data channel packets"
 		echo "and the tls-auth/tls-crypt control channel packets:"
 	fi

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -424,9 +424,9 @@ else
 			;;
 		esac
 	fi
-	if [[ $CIPHER = "1" && $CIPHER = "2" && $CIPHER = "3" ]]; then
+	if [[ $CIPHER = "cipher AES-256-GCM" ]] || [[ $CIPHER = "cipher AES-192-GCM" ]] || [[ $CIPHER = "cipher AES-128-GCM" ]]; then
 		echo "Choose which message digest algorithm you want to use for the tls-auth/tls-crypt control channel packets:"
-	elif [[ $CIPHER = "4" && $CIPHER = "5" && $CIPHER = "6" ]]; then
+	elif [[ $CIPHER = "cipher AES-256-CBC" ]] || [[ $CIPHER = "cipher AES-192-CBC" ]] || [[ $CIPHER = "cipher AES-128-CBC" ]]; then
 		echo "Choose which message digest algorithm you want to use for the data channel packets"
 		echo "and the tls-auth/tls-crypt control channel packets:"
 	fi

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -517,7 +517,6 @@ else
 		elif [[ "$VERSION_ID" = 'VERSION_ID="9"' ]]; then
 			echo "deb http://build.openvpn.net/debian/openvpn/stable stretch main" > /etc/apt/sources.list.d/openvpn.list
 			wget -O - https://swupdate.openvpn.net/repos/repo-public.gpg | apt-key add -
-			apt update
 		fi
 		# Ubuntu 14.04
 		elif [[ "$VERSION_ID" = 'VERSION_ID="14.04"' ]]; then

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -195,7 +195,7 @@ if [[ -e /etc/openvpn/server.conf ]]; then
 				else  # if not SUDO_USER, use /root
 					homeDir="/root"
 				fi
-				rm $homeDir*/.ovpn
+				rm $homeDir/*.ovpn
 				echo ""
 				echo "OpenVPN removed!"
 			else

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -598,7 +598,6 @@ set_var EASYRSA_CURVE $CERT_CURVE" > vars
 	chmod 644 /etc/openvpn/crl.pem
 
 	# Generate server.conf
-	echo "local $IP" > /etc/openvpn/server.conf
 	echo "port $PORT" >> /etc/openvpn/server.conf
 	if [[ "$PROTOCOL" = '1' ]]; then
 		echo "proto udp" >> /etc/openvpn/server.conf

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -237,6 +237,21 @@ else
 		read -p "DNS [1-6]: " -e -i 1 DNS
 	done
 	echo ""
+	echo "Choose which compression algorithm you want to use:"
+	echo "   1) LZ4 (faster)"
+	echo "   2) LZ0 (use for OpenVPN 2.3 compatibility"
+	while [[ $COMPRESSION != "1" && $COMPRESSION != "2" ]]; do
+		read -p "Compression algorithm [1-2]: " -e -i 1 COMPRESSION
+	done
+	case $COMPRESSION in
+		1)
+		COMPRESSION="lz4"
+		;;
+		2)
+		COMPRESSION="lzo"
+		;;
+	esac
+	echo ""
 	echo "See https://github.com/Angristan/OpenVPN-install#encryption to learn more about "
 	echo "the encryption in OpenVPN and the choices proposed in this script."
 	echo "Please note that all the choices proposed are secure enough considering today's strandards, unlike some default OpenVPN options"
@@ -664,6 +679,7 @@ ncp-disable
 tls-server
 tls-version-min 1.2
 tls-cipher $CC_ENC
+compress $COMPRESSION
 status openvpn.log
 verb 3" >> /etc/openvpn/server.conf
 

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -478,7 +478,7 @@ else
 		apt-get install ca-certificates -y
 		# We add the OpenVPN repo to get the latest version.
 		# Debian 8
-		elif [[ "$VERSION_ID" = 'VERSION_ID="8"' ]]; then
+		if [[ "$VERSION_ID" = 'VERSION_ID="8"' ]]; then
 			echo "deb http://build.openvpn.net/debian/openvpn/stable jessie main" > /etc/apt/sources.list.d/openvpn.list
 			wget -O - https://swupdate.openvpn.net/repos/repo-public.gpg | apt-key add -
 			apt update

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -57,9 +57,7 @@ fi
 
 newclient () {
 	# Where to write the custom client.ovpn?
-	if [ -e /home/$1 ]; then  # if $1 is a user name
-		homeDir="/home/$1"
-	elif [ ${SUDO_USER} ]; then   # if not, use SUDO_USER
+	if [ ${SUDO_USER} ]; then   # if not, use SUDO_USER
 		homeDir="/home/${SUDO_USER}"
 	else  # if not SUDO_USER, use /root
 		homeDir="/root"
@@ -191,6 +189,13 @@ if [[ -e /etc/openvpn/server.conf ]]; then
 				fi
 				rm -rf /etc/openvpn
 				rm -rf /usr/share/doc/openvpn*
+				# Where are the client files?
+				if [ ${SUDO_USER} ]; then   # if not, use SUDO_USER
+					homeDir="/home/${SUDO_USER}"
+				else  # if not SUDO_USER, use /root
+					homeDir="/root"
+				fi
+				rm $homeDir*/.ovpn
 				echo ""
 				echo "OpenVPN removed!"
 			else

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -78,6 +78,7 @@ newclient () {
 	#We verify if we used tls-crypt or tls-auth during the installation
 	TLS_SIG=$(cat /etc/openvpn/TLS_SIG)
 	if [[ $TLS_SIG == "1" ]]; then
+		echo "<tls-crypt>" >> ~/$1.ovpn
 		cat /etc/openvpn/tls-crypt.key >> ~/$1.ovpn
 		echo "</tls-crypt>" >> ~/$1.ovpn
 	elif [[ $TLS_SIG == "2" ]]; then

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -249,8 +249,9 @@ else
 	echo "Choose which compression algorithm you want to use:"
 	echo "   1) LZ4 (faster)"
 	echo "   2) LZ0 (use for OpenVPN 2.3 compatibility)"
-	while [[ $COMPRESSION != "1" && $COMPRESSION != "2" ]]; do
-		read -p "Compression algorithm [1-2]: " -e -i 1 COMPRESSION
+	echo "   3) No compression"
+	while [[ $COMPRESSION != "1" && $COMPRESSION != "2" && $COMPRESSION != "3" ]]; do
+		read -p "Compression algorithm [1-3]: " -e -i 1 COMPRESSION
 	done
 	case $COMPRESSION in
 		1)
@@ -258,6 +259,9 @@ else
 		;;
 		2)
 		COMPRESSION="lzo"
+		;;
+		3)
+		# We don't do anything
 		;;
 	esac
 	echo ""
@@ -734,9 +738,13 @@ $CIPHER
 ncp-disable
 tls-server
 tls-version-min 1.2
-tls-cipher $CC_ENC
-compress $COMPRESSION
-status openvpn.log
+tls-cipher $CC_ENC" >> /etc/openvpn/server.conf
+
+if [[ $COMPRESSION == "lz4" || $COMPRESSION == "lzo"  ]]; then
+	echo "compress $COMPRESSION" >> /etc/openvpn/server.conf
+fi
+
+echo "status openvpn.log
 verb 3" >> /etc/openvpn/server.conf
 
 	# Create the sysctl configuration file if needed (mainly for Arch Linux)
@@ -872,8 +880,13 @@ auth $HMAC_AUTH
 $CIPHER
 tls-client
 tls-version-min 1.2
-tls-cipher $CC_ENC
-setenv opt block-outside-dns
+tls-cipher $CC_ENC" >> /etc/openvpn/client-template.txt
+
+if [[ $COMPRESSION == "lz4" || $COMPRESSION == "lzo"  ]]; then
+	echo "compress $COMPRESSION" >> /etc/openvpn/client-template.txt
+fi
+
+echo "setenv opt block-outside-dns
 verb 3" >> /etc/openvpn/client-template.txt
 
 	# Generate the custom client.ovpn

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -243,7 +243,6 @@ else
 	echo "unlike some default OpenVPN options"
 	echo ''
 	echo "Choose which cipher you want to use for the data channel:"
-	echo ""
 	echo "   1) AES-128-GCM (recommended)"
 	echo "   2) AES-192-GCM"
 	echo "   3) AES-256-GCM"
@@ -285,6 +284,7 @@ else
 	done
 	case $DH_TYPE in
 		1)
+			echo ""
 			echo "Choose which curve you want to use"
 			echo "   1) secp256r1"
 			echo "   2) secp384r1 (recommended)"
@@ -305,7 +305,8 @@ else
 			esac
 		;;
 		2)
-		echo "Choose which DH key size do you want to use"
+			echo""
+			echo "Choose which DH key size do you want to use"
 			echo "   1) 2048 bits"
 			echo "   2) 3072 bits (recommended)"
 			echo "   3) 4096 bits"
@@ -336,6 +337,7 @@ else
 	done
 	case $CERT_TYPE in
 		1)
+			echo ""
 			echo "Choose which curve you want to use:"
 			echo "   1) secp256r1"
 			echo "   2) secp384r1 (recommended)"
@@ -356,7 +358,8 @@ else
 			esac
 		;;
 		2)
-		echo "Choose which RSA key size do you want to use:"
+			echo ""
+			echo "Choose which RSA key size do you want to use:"
 			echo "   1) 2048 bits"
 			echo "   2) 3072 bits (recommended)"
 			echo "   3) 4096 bits"
@@ -376,6 +379,7 @@ else
 			esac
 		;;
 	esac
+	echo ""
 	echo "Choose which hash algorithm you want to use for the certificate:"
 	echo "   1) SHA-256"
 	echo "   2) SHA-384 (recommended)"
@@ -394,6 +398,7 @@ else
 			CERT_HASH="sha512"
 		;;
 	esac
+	echo ""
 	echo "Which cipher to use for the control channel ?"
 	if [[ "$CERT_TYPE" = '1' ]]; then
 		echo "   1) ECDHE-ECDSA-AES-256-GCM-SHA384 (recommended)"
@@ -424,6 +429,7 @@ else
 			;;
 		esac
 	fi
+	echo""
 	if [[ $CIPHER = "cipher AES-256-GCM" ]] || [[ $CIPHER = "cipher AES-192-GCM" ]] || [[ $CIPHER = "cipher AES-128-GCM" ]]; then
 		echo "Choose which message digest algorithm you want to use for the tls-auth/tls-crypt control channel packets:"
 	elif [[ $CIPHER = "cipher AES-256-CBC" ]] || [[ $CIPHER = "cipher AES-192-CBC" ]] || [[ $CIPHER = "cipher AES-128-CBC" ]]; then
@@ -447,6 +453,7 @@ else
 			HMAC_AUTH="SHA512"
 		;;
 	esac
+	echo ""
 	echo "tls crypt or tls auth"
 	echo "   1) tls-crypt (recommended)"
 	echo "   2) tls-auth (use only for openvpn 2.3 compat)"

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -424,7 +424,13 @@ else
 			;;
 		esac
 	fi
-	echo "Choose which HMAC authentication algorithm you want to use"
+	if [[ $CIPHER != "1" && $CIPHER != "2" && $CIPHER != "3" ]]; then
+		echo "Choose which message digest algorithm you want to use for the tls-auth/tls-crypt control channel packets:"
+	fi
+	if [[ $CIPHER != "4" && $CIPHER != "5" && $CIPHER != "6" ]]; then
+		echo "Choose which message digest algorithm you want to use for the data channel packets"
+		echo "and the tls-auth/tls-crypt control channel packets:"
+	fi
 	echo "   1) SHA-256"
 	echo "   2) SHA-384 (recommended)"
 	echo "   3) SHA-512"


### PR DESCRIPTION
This is WIP for adding OpenVPN 2.4 new features into the script

- Add support for AES-GCM ciphers for the data channel
- Add support for tls-crypt
- Add support for ECDSA certificates
- Add support for ECDHE
- Add choice for HMAC auth algorithm
- Add choice for certificate hash algorithm
- Add choice for the control channel's cipher

All these options have an OpenVPN 2.3-compatible choice (example : RSA cert and DH key)

In my previous PR, I removed the encryptions choices to only choose the best ones. Here I've added the choice for every encryption parameter, as it seems that users prefer to use the script this way.

It seems to be working, I'll have to dome some more testing, rewrite some menus and then rewrite the readme with to add the new features.