### PR TITLE
Update openvpn-install.sh

### DIFF
--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -78,6 +78,7 @@ newclient () {
 	#We verify if we used tls-crypt or tls-auth during the installation
 	TLS_SIG=$(cat /etc/openvpn/TLS_SIG)
 	if [[ $TLS_SIG == "1" ]]; then
+		echo "<tls-crypt>" >> ~/$1.ovpn
 		cat /etc/openvpn/tls-crypt.key >> ~/$1.ovpn
 		echo "</tls-crypt>" >> ~/$1.ovpn
 	elif [[ $TLS_SIG == "2" ]]; then


### PR DESCRIPTION
`Add echo "<tls-crypt>" >> ~/$1.ovpn`

After generating config, openvpn client on Windows is unable to start because of missing `<tls-crypt>` in config.
