### PR TITLE
Add Quad9 DNS

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,13 +90,13 @@ The script will ask you which DNS resolvers you want to use when connected to th
 Here are the possibilities :
 
 - Current system resolvers, those that are in `/etc/resolv.conf`
+- [Quad9](https://www.quad9.net), recommended, security and privacy oriented, fast worldwide (Anycast servers)
 - [FDN's DNS Servers](http://www.fdn.fr/actions/dns/), recommended if you're in western europe (France)
 - [DNS.WATCH DNS Servers](https://dns.watch/index), recommended if you're in western europe (Germany)
 - [OpenDNS](https://en.wikipedia.org/wiki/OpenDNS), not recommened but fast wordlwide (Anycast servers)
 - [Google Public DNS](https://en.wikipedia.org/wiki/Google_Public_DNS), not recommended, but fast worldwide (Anycast servers)
 - [Yandex Basic DNS](https://dns.yandex.com/), not recommended, but fast in Russia
 - [AdGuard DNS](https://github.com/AdguardTeam/AdguardDNS), located in Russia, blocks ads and trackers
-- [IBM Quad9](https://www.quad9.net), security oriented, fast worldwide (Anycast servers)
 - Soon : local resolver :D
 
 Any other fast, trustable and neutral servers proposition is welcome.

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Here are the possibilities :
 - [Google Public DNS](https://en.wikipedia.org/wiki/Google_Public_DNS), not recommended, but fast worldwide (Anycast servers)
 - [Yandex Basic DNS](https://dns.yandex.com/), not recommended, but fast in Russia
 - [AdGuard DNS](https://github.com/AdguardTeam/AdguardDNS), located in Russia, blocks ads and trackers
+- [IBM Quad9](https://www.quad9.net), security oriented, fast worldwide (Anycast servers)
 - Soon : local resolver :D
 
 Any other fast, trustable and neutral servers proposition is welcome.

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -227,7 +227,8 @@ else
 	echo "   5) Google (Anycast: worldwide)"
 	echo "   6) Yandex Basic (Russia)"
 	echo "   7) AdGuard DNS (Russia)"
-	while [[ $DNS != "1" && $DNS != "2" && $DNS != "3" && $DNS != "4" && $DNS != "5" && $DNS != "6" && $DNS != "7" ]]; do
+	echo "   8) Quad9 (Anycast: worldwide)"
+	while [[ $DNS != "1" && $DNS != "2" && $DNS != "3" && $DNS != "4" && $DNS != "5" && $DNS != "6" && $DNS != "7" && $DNS != "8" ]]; do
 		read -p "DNS [1-7]: " -e -i 1 DNS
 	done
 	echo ""
@@ -432,7 +433,7 @@ WantedBy=multi-user.target" > /etc/systemd/system/iptables.service
 			echo "Ok, bye !"
 			exit 4
 		fi
-		
+
 		if [[ "$OS" = 'arch' ]]; then
 			# Install dependencies
 			pacman -Syu openvpn iptables openssl wget ca-certificates curl --needed --noconfirm
@@ -523,6 +524,9 @@ ifconfig-pool-persist ipp.txt" >> /etc/openvpn/server.conf
 		7) #AdGuard DNS
 		echo 'push "dhcp-option DNS 176.103.130.130"' >> /etc/openvpn/server.conf
 		echo 'push "dhcp-option DNS 176.103.130.131"' >> /etc/openvpn/server.conf
+		;;
+		8) #Quad9
+		echo 'push "dhcp-option DNS 9.9.9.9"' >> /etc/openvpn/server.conf
 		;;
 	esac
 echo 'push "redirect-gateway def1 bypass-dhcp" '>> /etc/openvpn/server.conf

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -501,32 +501,32 @@ ifconfig-pool-persist ipp.txt" >> /etc/openvpn/server.conf
 			echo "push \"dhcp-option DNS $line\"" >> /etc/openvpn/server.conf
 		done
 		;;
-		2) #FDN
+		2) #Quad9
+		echo 'push "dhcp-option DNS 9.9.9.9"' >> /etc/openvpn/server.conf
+		;;
+		3) #FDN
 		echo 'push "dhcp-option DNS 80.67.169.12"' >> /etc/openvpn/server.conf
 		echo 'push "dhcp-option DNS 80.67.169.40"' >> /etc/openvpn/server.conf
 		;;
-		3) #DNS.WATCH
+		4) #DNS.WATCH
 		echo 'push "dhcp-option DNS 84.200.69.80"' >> /etc/openvpn/server.conf
 		echo 'push "dhcp-option DNS 84.200.70.40"' >> /etc/openvpn/server.conf
 		;;
-		4) #OpenDNS
+		5) #OpenDNS
 		echo 'push "dhcp-option DNS 208.67.222.222"' >> /etc/openvpn/server.conf
 		echo 'push "dhcp-option DNS 208.67.220.220"' >> /etc/openvpn/server.conf
 		;;
-		5) #Google
+		6) #Google
 		echo 'push "dhcp-option DNS 8.8.8.8"' >> /etc/openvpn/server.conf
 		echo 'push "dhcp-option DNS 8.8.4.4"' >> /etc/openvpn/server.conf
 		;;
-		6) #Yandex Basic
+		7) #Yandex Basic
 		echo 'push "dhcp-option DNS 77.88.8.8"' >> /etc/openvpn/server.conf
 		echo 'push "dhcp-option DNS 77.88.8.1"' >> /etc/openvpn/server.conf
 		;;
-		7) #AdGuard DNS
+		8) #AdGuard DNS
 		echo 'push "dhcp-option DNS 176.103.130.130"' >> /etc/openvpn/server.conf
 		echo 'push "dhcp-option DNS 176.103.130.131"' >> /etc/openvpn/server.conf
-		;;
-		8) #Quad9
-		echo 'push "dhcp-option DNS 9.9.9.9"' >> /etc/openvpn/server.conf
 		;;
 	esac
 echo 'push "redirect-gateway def1 bypass-dhcp" '>> /etc/openvpn/server.conf

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -220,16 +220,16 @@ else
 	done
 	echo ""
 	echo "What DNS do you want to use with the VPN?"
-	echo "   1) Current system resolvers (in /etc/resolv.conf)"
-	echo "   2) FDN (France)"
-	echo "   3) DNS.WATCH (Germany)"
-	echo "   4) OpenDNS (Anycast: worldwide)"
-	echo "   5) Google (Anycast: worldwide)"
-	echo "   6) Yandex Basic (Russia)"
-	echo "   7) AdGuard DNS (Russia)"
-	echo "   8) Quad9 (Anycast: worldwide)"
+	echo "   1) Current system resolvers (from /etc/resolv.conf)"
+	echo "   2) Quad9 (Anycast: worldwide)"
+	echo "   3) FDN (France)"
+	echo "   4) DNS.WATCH (Germany)"
+	echo "   5) OpenDNS (Anycast: worldwide)"
+	echo "   6) Google (Anycast: worldwide)"
+	echo "   7) Yandex Basic (Russia)"
+	echo "   8) AdGuard DNS (Russia)"
 	while [[ $DNS != "1" && $DNS != "2" && $DNS != "3" && $DNS != "4" && $DNS != "5" && $DNS != "6" && $DNS != "7" && $DNS != "8" ]]; do
-		read -p "DNS [1-7]: " -e -i 1 DNS
+		read -p "DNS [1-8]: " -e -i 1 DNS
 	done
 	echo ""
 	echo "See https://github.com/Angristan/OpenVPN-install#encryption to learn more about "


### PR DESCRIPTION
New option from IBM and the [GCA](https://www.globalcyberalliance.org/).

The pitch is fast and private with added security against confirmed threat.

> Quad9 is a free, recursive, anycast DNS platform that provides end users robust security protections, high-performance, and privacy. 

> Quad9 blocks against known malicious domains, preventing your computers and IoT devices from connecting malware or phishing sites. Whenever a Quad9 user clicks on a website link or types in an address into a web browser, Quad9 will check the site against the IBM X-Force threat intelligence database of over 40 billion analyzed web pages and images.

> Privacy: No personally-identifiable information is collected by the system. IP addresses of end users are not stored to disk or distributed outside of the equipment answering the query in the local data center. Quad9 is a nonprofit organization dedicated only to the operation of DNS services. There are no other secondary revenue streams for personally-identifiable data, and the core charter of the organization is to provide secure, fast, private DNS. 

https://www.quad9.net/#/about