### PR TITLE
Fixed wrong home directory on newclient()

### DIFF
--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -78,9 +78,9 @@ newclient () {
 	#We verify if we used tls-crypt or tls-auth during the installation
 	TLS_SIG=$(cat /etc/openvpn/TLS_SIG)
 	if [[ $TLS_SIG == "1" ]]; then
-		echo "<tls-crypt>" >> ~/$1.ovpn
-		cat /etc/openvpn/tls-crypt.key >> ~/$1.ovpn
-		echo "</tls-crypt>" >> ~/$1.ovpn
+		echo "<tls-crypt>" >> $homeDir/$1.ovpn
+		cat /etc/openvpn/tls-crypt.key >> $homeDir/$1.ovpn
+		echo "</tls-crypt>" >> $homeDir/$1.ovpn
 	elif [[ $TLS_SIG == "2" ]]; then
 		echo "key-direction 1" >> $homeDir/$1.ovpn
 		echo "<tls-auth>" >> $homeDir/$1.ovpn


### PR DESCRIPTION
Fixed some errors on the script that keep the client and server from doing the TLS handshake.
Also, i can confirm this is working on Fedora 27 and Fedora 27 armhf, but notice that the curve secp256r1 is not supported, only secp256k1 in neither the x86_64 or the armhf versions