### PR TITLE
Add password option for clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ This fork includes the following features :
 - [Arch Linux support](https://github.com/Angristan/OpenVPN-install/pull/2)
 - Up-to-date OpenVPN thanks to [EPEL](http://fedoraproject.org/wiki/EPEL) for CentOS and [swupdate.openvpn.net](https://community.openvpn.net/openvpn/wiki/OpenvpnSoftwareRepos) for Ubuntu and Debian. These are third-party yet trusted repositories.
 - Randomized certificate name
+- The ability to create passwordless clients and clients protected with a password
 - Other improvements !
 
 ## DNS

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -127,7 +127,7 @@ if [[ -e /etc/openvpn/server.conf ]]; then
 				./easyrsa build-client-full $CLIENT nopass
 				;;
 				2)
-				echo "⚠️ You will be asked for the client password below"
+				echo "⚠️ You will be asked for the client password below ⚠️"
 				./easyrsa build-client-full $CLIENT
 				;;
 			esac
@@ -508,7 +508,7 @@ WantedBy=multi-user.target" > /etc/systemd/system/iptables.service
 			./easyrsa build-client-full $CLIENT nopass
 		;;
 		2)
-			echo "⚠️ You will be asked for the client password below"
+			echo "⚠️ You will be asked for the client password below ⚠️"
 			./easyrsa build-client-full $CLIENT
 		;;
 	esac

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -122,6 +122,7 @@ if [[ -e /etc/openvpn/server.conf ]]; then
 			cd /etc/openvpn/easy-rsa/
 			case $pass in
 				1)
+				echo "⚠️ You will be asked for the client password below"
 				./easyrsa build-client-full $CLIENT nopass
 				;;
 				2)
@@ -500,6 +501,7 @@ WantedBy=multi-user.target" > /etc/systemd/system/iptables.service
 	./easyrsa build-server-full $SERVER_NAME nopass
 	case $pass in
 		1)
+			echo "⚠️ You will be asked for the client password below"
 			./easyrsa build-client-full $CLIENT nopass
 		;;
 		2)

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -118,7 +118,7 @@ if [[ -e /etc/openvpn/server.conf ]]; then
 			echo ""
 			echo "Tell me a name for the client cert"
 			echo "Please, use one word only, no special characters"
-			read -p "Client name: " -e -i client2 CLIENT
+			read -p "Client name: " -e -i client CLIENT
 			cd /etc/openvpn/easy-rsa/
 			case $pass in
 				1)

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -114,7 +114,9 @@ if [[ -e /etc/openvpn/server.conf ]]; then
 			echo "(e.g. encrypt the private key with a password)"
 			echo "   1) Add a passwordless client"
 			echo "   2) Use a password for the client"
-			read -p "Select an option [1-2]: " pass
+			until [[ "$pass" =~ ^[1-2]$ ]]; do
+				read -rp "Select an option [1-2]: " -e -i 1 pass
+			done
 			echo ""
 			echo "Tell me a name for the client cert"
 			echo "Please, use one word only, no special characters"
@@ -334,7 +336,9 @@ else
 	echo "(e.g. encrypt the private key with a password)"
 	echo "   1) Add a passwordless client"
 	echo "   2) Use a password for the client"
-	read -p "Select an option [1-2]: " pass
+	until [[ "$pass" =~ ^[1-2]$ ]]; do
+		read -rp "Select an option [1-2]: " -e -i 1 pass
+	done
 	echo ""
 	echo "Finally, tell me a name for the client certificate and configuration"
 	while [[ $CLIENT = "" ]]; do

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -110,11 +110,24 @@ if [[ -e /etc/openvpn/server.conf ]]; then
 		case $option in
 			1)
 			echo ""
+			echo "Do you want to protect the configuration file with a password?"
+			echo "(e.g. encrypt the private key with a password)"
+			echo "   1) Add a passwordless client"
+			echo "   2) Use a password for the client"
+			read -p "Select an option [1-2]: " pass
+			echo ""
 			echo "Tell me a name for the client cert"
 			echo "Please, use one word only, no special characters"
-			read -p "Client name: " -e -i client CLIENT
+			read -p "Client name: " -e -i client2 CLIENT
 			cd /etc/openvpn/easy-rsa/
-			./easyrsa build-client-full $CLIENT nopass
+			case $pass in
+				1)
+				./easyrsa build-client-full $CLIENT nopass
+				;;
+				2)
+				./easyrsa build-client-full $CLIENT
+				;;
+			esac
 			# Generates the custom client.ovpn
 			newclient "$CLIENT"
 			echo ""
@@ -316,6 +329,12 @@ else
 		;;
 	esac
 	echo ""
+	echo "Do you want to protect the configuration file with a password?"
+	echo "(e.g. encrypt the private key with a password)"
+	echo "   1) Add a passwordless client"
+	echo "   2) Use a password for the client"
+	read -p "Select an option [1-2]: " pass
+	echo ""
 	echo "Finally, tell me a name for the client certificate and configuration"
 	while [[ $CLIENT = "" ]]; do
 		echo "Please, use one word only, no special characters"
@@ -479,7 +498,14 @@ WantedBy=multi-user.target" > /etc/systemd/system/iptables.service
 	./easyrsa --batch build-ca nopass
 	openssl dhparam -out dh.pem $DH_KEY_SIZE
 	./easyrsa build-server-full $SERVER_NAME nopass
-	./easyrsa build-client-full $CLIENT nopass
+	case $pass in
+		1)
+			./easyrsa build-client-full $CLIENT nopass
+		;;
+		2)
+			./easyrsa build-client-full $CLIENT
+		;;
+	esac
 	EASYRSA_CRL_DAYS=3650 ./easyrsa gen-crl
 	# generate tls-auth key
 	openvpn --genkey --secret /etc/openvpn/tls-auth.key

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -122,10 +122,10 @@ if [[ -e /etc/openvpn/server.conf ]]; then
 			cd /etc/openvpn/easy-rsa/
 			case $pass in
 				1)
-				echo "⚠️ You will be asked for the client password below"
 				./easyrsa build-client-full $CLIENT nopass
 				;;
 				2)
+				echo "⚠️ You will be asked for the client password below"
 				./easyrsa build-client-full $CLIENT
 				;;
 			esac
@@ -501,10 +501,10 @@ WantedBy=multi-user.target" > /etc/systemd/system/iptables.service
 	./easyrsa build-server-full $SERVER_NAME nopass
 	case $pass in
 		1)
-			echo "⚠️ You will be asked for the client password below"
 			./easyrsa build-client-full $CLIENT nopass
 		;;
 		2)
+			echo "⚠️ You will be asked for the client password below"
 			./easyrsa build-client-full $CLIENT
 		;;
 	esac


### PR DESCRIPTION
This PR adds the option to add a password to the client file. It will be asked when connecting to the OpenVPN server. Basically, this encrypts the client's private key with a password.

Using a password for your private key is more secure, as not having one mean anyone with your .ovpn file can connect to your server and/or decrypt your traffic if they manage to make a MitM.

The user will be given the option when installing the server for the first time (and thus creating the first user) and when adding new users.