### PR TITLE
Added support for Ubuntu 16.04 on armhf to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The script is made to work on these OS and architectures :
 - **Debian 8** (i386, amd64)
 - **Debian 9** (i386, amd64, armhf, arm64)
 - **Ubuntu 14.04 LTS** (i386, amd64)
-- **Ubuntu 16.04 LTS** (i386, amd64)
+- **Ubuntu 16.04 LTS** (i386, amd64, armhf)
 - **Ubuntu 17.10** (i386, amd64, armhf, arm64)
 - **Fedora 25** (amd64)
 - **Fedora 26** (amd64)


### PR DESCRIPTION
I just installed OpenVPN on Ubuntu 16.04 running on armhf using your script. Installation went fine, I am able to connect and data transfer seems stable as well. I assume it would run on arm64 on Ubuntu 16.04 as well but I do not have the hardware to test this.

Looking through the issues I only found an issue related to Ubuntu 14.04 on armhf. Perhaps that issue issue is 14.04 only?