### PR TITLE
TCP_NODELAY

### DIFF
--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -690,7 +690,6 @@ WantedBy=multi-user.target" > /etc/systemd/system/iptables.service
 	elif [[ "$PROTOCOL" = '2' ]]; then
 		echo "proto tcp" >> /etc/openvpn/server.conf
 		echo "socket-flags TCP_NODELAY" >> /etc/openvpn/server.conf
-		echo "push "socket-flags TCP_NODELAY"" >> /etc/openvpn/server.conf
 	fi
 	echo "dev tun
 user nobody
@@ -884,6 +883,7 @@ verb 3" >> /etc/openvpn/server.conf
 		echo "proto udp" >> /etc/openvpn/client-template.txt
 	elif [[ "$PROTOCOL" = '2' ]]; then
 		echo "proto tcp-client" >> /etc/openvpn/client-template.txt
+		echo "socket-flags TCP_NODELAY" >> /etc/openvpn/client-template.txt
 	fi
 	echo "remote $IP $PORT
 dev tun

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -689,6 +689,8 @@ WantedBy=multi-user.target" > /etc/systemd/system/iptables.service
 		echo "proto udp" >> /etc/openvpn/server.conf
 	elif [[ "$PROTOCOL" = '2' ]]; then
 		echo "proto tcp" >> /etc/openvpn/server.conf
+		echo "socket-flags TCP_NODELAY" >> /etc/openvpn/server.conf
+		echo "push "socket-flags TCP_NODELAY"" >> /etc/openvpn/server.conf
 	fi
 	echo "dev tun
 user nobody


### PR DESCRIPTION
Add tcp_nodelay option for proto tcp

 --tcp-nodelay
              This  macro sets the TCP_NODELAY socket flag on the server as well as pushes it to
              connecting clients.  The TCP_NODELAY flag disables  the  Nagle  algorithm  on  TCP
              sockets  causing  packets  to  be transmitted immediately with low latency, rather
              than waiting a short period of time in order to aggregate several packets  into  a
              larger  containing packet.  In VPN applications over TCP, TCP_NODELAY is generally
              a good latency optimization.