### PR TITLE
Add IPv6 NAT support

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ This fork includes the following features :
 - [Arch Linux support](https://github.com/Angristan/OpenVPN-install/pull/2)
 - Up-to-date OpenVPN thanks to [EPEL](http://fedoraproject.org/wiki/EPEL) for CentOS and [swupdate.openvpn.net](https://community.openvpn.net/openvpn/wiki/OpenvpnSoftwareRepos) for Ubuntu and Debian. These are third-party yet trusted repositories.
 - Randomized certificate name
+- IPv6 (NATed) support
 - Other improvements !
 
 ## DNS

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -603,7 +603,7 @@ verb 3" >> /etc/openvpn/server.conf
 	# Enable routing
 	echo 'net.ipv4.ip_forward=1' >> $SYSCTL
 	if [[ "$IPV6" = 'y' ]]; then
-		echo 'net.ipv6.ip_forward=1' >> $SYSCTL
+		echo 'net.ipv6.conf.all.forwarding=1' >> $SYSCTL
 	fi
 	# Avoid an unneeded reboot
 	sysctl -p

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -502,10 +502,18 @@ WantedBy=multi-user.target" > /etc/systemd/system/iptables.service
 
 	# Generate server.conf
 	echo "port $PORT" > /etc/openvpn/server.conf
-	if [[ "$PROTOCOL" = 'UDP' ]]; then
-		echo "proto udp" >> /etc/openvpn/server.conf
-	elif [[ "$PROTOCOL" = 'TCP' ]]; then
-		echo "proto tcp" >> /etc/openvpn/server.conf
+	if [[ "$IPV6" = 'n' ]]; then
+		if [[ "$PROTOCOL" = 'UDP' ]]; then
+			echo "proto udp" >> /etc/openvpn/server.conf
+		elif [[ "$PROTOCOL" = 'TCP' ]]; then
+			echo "proto tcp" >> /etc/openvpn/server.conf
+		fi
+	elif [ "$IPV6" = 'y' ]]; then
+		if [[ "$PROTOCOL" = 'UDP' ]]; then
+			echo "proto udp6" >> /etc/openvpn/server.conf
+		elif [[ "$PROTOCOL" = 'TCP' ]]; then
+			echo "proto tcp6" >> /etc/openvpn/server.conf
+		fi
 	fi
 	echo "dev tun
 user nobody
@@ -567,7 +575,6 @@ ifconfig-pool-persist ipp.txt" >> /etc/openvpn/server.conf
 
 	if [[ "$IPV6" = 'y' ]]; then
 		echo 'server-ipv6 fd6c:62d9:eb8c::/112
-proto udp6
 tun-ipv6
 push tun-ipv6
 push "route-ipv6 2000::/3"

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -359,16 +359,19 @@ else
 		if [[ "$VERSION_ID" = 'VERSION_ID="7"' ]]; then
 			echo "deb http://build.openvpn.net/debian/openvpn/stable wheezy main" > /etc/apt/sources.list.d/openvpn.list
 			wget -O - https://swupdate.openvpn.net/repos/repo-public.gpg | apt-key add -
+			apt-get update
 		fi
 		# Debian 8
 		if [[ "$VERSION_ID" = 'VERSION_ID="8"' ]]; then
 			echo "deb http://build.openvpn.net/debian/openvpn/stable jessie main" > /etc/apt/sources.list.d/openvpn.list
 			wget -O - https://swupdate.openvpn.net/repos/repo-public.gpg | apt-key add -
+			apt-get update
 		fi
 		# Ubuntu 14.04
 		if [[ "$VERSION_ID" = 'VERSION_ID="14.04"' ]]; then
 			echo "deb http://build.openvpn.net/debian/openvpn/stable trusty main" > /etc/apt/sources.list.d/openvpn.list
 			wget -O - https://swupdate.openvpn.net/repos/repo-public.gpg | apt-key add -
+			apt-get update
 		fi
 		# Ubuntu >= 16.04 and Debian > 8 have OpenVPN > 2.3.3 without the need of a third party repository.
 		# The we install OpenVPN

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -236,7 +236,7 @@ else
 	fi
 	echo ""
 	while [[ $IPV6 != "y" && $IPV6 != "n" ]]; do
-		read -p "Do you want to enable IPv6 support? [y/n]: " -e -i n IPV6
+		read -p "Do you want to enable IPv6 support? [y/n]: " -e IPV6
 	done
 	echo ""
 	echo "What port do you want for OpenVPN?"

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -359,7 +359,7 @@ else
 
 	# Autodetect IP address and pre-fill for the user
 	IP=$(ip addr | grep 'inet' | grep -v inet6 | grep -vE '127\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' | grep -oE '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' | head -1)
-	read -p "IP address: " -e -i $IP IP
+	read -rp "IP address: " -e -i $IP IP
 	# If $IP is a private IP address, the server must be behind NAT
 	if echo "$IP" | grep -qE '^(10\.|172\.1[6789]\.|172\.2[0-9]\.|172\.3[01]\.|192\.168)'; then
 		echo ""
@@ -377,7 +377,7 @@ else
 	fi
 	echo ""
 	while [[ $IPV6 != "y" && $IPV6 != "n" ]]; do
-		read -p "Do you want to enable IPv6 support? [y/n]: " -e IPV6
+		read -rp "Do you want to enable IPv6 support? [y/n]: " -e IPV6
 	done
 	echo ""
 	echo "What port do you want for OpenVPN?"

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -219,22 +219,14 @@ else
 	# Autodetect IP address and pre-fill for the user
 	IP=$(ip addr | grep 'inet' | grep -v inet6 | grep -vE '127\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' | grep -oE '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' | head -1)
 	read -p "IP address: " -e -i $IP IP
-	echo ""
-	echo "What port do you want for OpenVPN?"
-	read -p "Port: " -e -i 1194 PORT
 	# If $IP is a private IP address, the server must be behind NAT
 	if echo "$IP" | grep -qE '^(10\.|172\.1[6789]\.|172\.2[0-9]\.|172\.3[01]\.|192\.168)'; then
 		echo ""
 		echo "This server is behind NAT. What is the public IPv4 address or hostname?"
 		read -p "Public IP address / hostname: " -e PUBLICIP
 	fi
-	echo ""
-	echo "What protocol do you want for OpenVPN?"
-	echo "Unless UDP is blocked, you should not use TCP (unnecessarily slower)"
-	while [[ $PROTOCOL != "UDP" && $PROTOCOL != "TCP" ]]; do
-		read -p "Protocol [UDP/TCP]: " -e -i UDP PROTOCOL
-	done
 	ping6 -c4 ipv6.google.com > /dev/null 2>&1;
+	echo ""
 	if [[ $? == 0 ]]; then
 		echo "Your host appears to have IPv6 connectivity."
 	else
@@ -244,6 +236,15 @@ else
 	echo "Do you want to enable IPv6 support?"
 	while [[ $IPV6 != "y" && $IPV6 != "n" ]]; do
 		read -p "IPv6 support? [y/n]: " -e -i n IPV6
+	done
+	echo ""
+	echo "What port do you want for OpenVPN?"
+	read -p "Port: " -e -i 1194 PORT
+	echo ""
+	echo "What protocol do you want for OpenVPN?"
+	echo "Unless UDP is blocked, you should not use TCP (unnecessarily slower)"
+	while [[ $PROTOCOL != "UDP" && $PROTOCOL != "TCP" ]]; do
+		read -p "Protocol [UDP/TCP]: " -e -i UDP PROTOCOL
 	done
 	echo ""
 	echo "What DNS do you want to use with the VPN?"

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -350,25 +350,23 @@ else
 	read -n1 -r -p "Press any key to continue..."
 
 	if [[ "$OS" = 'debian' ]]; then
+		apt-get update
 		apt-get install ca-certificates gnupg -y
 		# We add the OpenVPN repo to get the latest version.
 		# Debian 7
 		if [[ "$VERSION_ID" = 'VERSION_ID="7"' ]]; then
 			echo "deb http://build.openvpn.net/debian/openvpn/stable wheezy main" > /etc/apt/sources.list.d/openvpn.list
 			wget -O - https://swupdate.openvpn.net/repos/repo-public.gpg | apt-key add -
-			apt-get update
 		fi
 		# Debian 8
 		if [[ "$VERSION_ID" = 'VERSION_ID="8"' ]]; then
 			echo "deb http://build.openvpn.net/debian/openvpn/stable jessie main" > /etc/apt/sources.list.d/openvpn.list
 			wget -O - https://swupdate.openvpn.net/repos/repo-public.gpg | apt-key add -
-			apt update
 		fi
 		# Ubuntu 14.04
 		if [[ "$VERSION_ID" = 'VERSION_ID="14.04"' ]]; then
 			echo "deb http://build.openvpn.net/debian/openvpn/stable trusty main" > /etc/apt/sources.list.d/openvpn.list
 			wget -O - https://swupdate.openvpn.net/repos/repo-public.gpg | apt-key add -
-			apt-get update
 		fi
 		# Ubuntu >= 16.04 and Debian > 8 have OpenVPN > 2.3.3 without the need of a third party repository.
 		# The we install OpenVPN

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -615,7 +615,7 @@ verb 3" >> /etc/openvpn/server.conf
 		echo 'net.ipv6.conf.all.forwarding=1' >> $SYSCTL
 	fi
 	# Avoid an unneeded reboot
-	sysctl -p
+	sysctl --system
 	# Set NAT for the VPN subnet
 	iptables -t nat -A POSTROUTING -o $NIC -s 10.8.0.0/24 -j MASQUERADE
 	if [[ "$IPV6" = 'y' ]]; then

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -508,7 +508,7 @@ WantedBy=multi-user.target" > /etc/systemd/system/iptables.service
 		elif [[ "$PROTOCOL" = 'TCP' ]]; then
 			echo "proto tcp" >> /etc/openvpn/server.conf
 		fi
-	elif [ "$IPV6" = 'y' ]]; then
+	elif [[ "$IPV6" = 'y' ]]; then
 		if [[ "$PROTOCOL" = 'UDP' ]]; then
 			echo "proto udp6" >> /etc/openvpn/server.conf
 		elif [[ "$PROTOCOL" = 'TCP' ]]; then

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -234,6 +234,12 @@ else
 	while [[ $PROTOCOL != "UDP" && $PROTOCOL != "TCP" ]]; do
 		read -p "Protocol [UDP/TCP]: " -e -i UDP PROTOCOL
 	done
+	ping6 -c4 ipv6.google.com > /dev/null 2>&1;
+	if [[ $? == 0 ]]; then
+		echo "Your host appears to have IPv6 connectivity."
+	else
+		echo "Your host does not appear to have IPv6 connectivity."
+	fi
 	echo ""
 	echo "Do you want to enable IPv6 support?"
 	while [[ $IPV6 != "y" && $IPV6 != "n" ]]; do

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -381,7 +381,27 @@ else
 	done
 	echo ""
 	echo "What port do you want for OpenVPN?"
-	read -p "Port: " -e -i 1194 PORT
+	echo "   1) Default: 1194"
+	echo "   2) Custom"
+	echo "   3) Random [49152-65535]"
+	until [[ "$PORT_CHOICE" =~ ^[1-3]$ ]]; do
+		read -p "Port choice [1-3]: " -e -i 1 PORT_CHOICE
+	done
+	case $PORT_CHOICE in
+		1)
+			PORT="1194"
+		;;
+		2)
+			until [[ "$PORT" =~ ^[0-9]+$ ]] && [ "$PORT" -ge 1 -a "$PORT" -le 65535 ]; do
+				read -p "Custom port [1-65535]: " -e -i 1194 PORT
+			done
+		;;
+		3)
+			# Generate random number within private ports range
+			PORT=$(shuf -i49152-65535 -n1)
+			echo "Random Port: $PORT"
+		;;
+	esac
 	echo ""
 	echo "What protocol do you want for OpenVPN?"
 	echo "Unless UDP is blocked, you should not use TCP (unnecessarily slower)"

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -225,6 +225,8 @@ else
 		echo "This server is behind NAT. What is the public IPv4 address or hostname?"
 		read -p "Public IP address / hostname: " -e PUBLICIP
 	fi
+	echo ""
+	echo "Checking for IPv6 connectivity..."
 	ping6 -c4 ipv6.google.com > /dev/null 2>&1;
 	echo ""
 	if [[ $? == 0 ]]; then
@@ -233,9 +235,8 @@ else
 		echo "Your host does not appear to have IPv6 connectivity."
 	fi
 	echo ""
-	echo "Do you want to enable IPv6 support?"
 	while [[ $IPV6 != "y" && $IPV6 != "n" ]]; do
-		read -p "IPv6 support? [y/n]: " -e -i n IPV6
+		read -p "Do you want to enable IPv6 support? [y/n]: " -e -i n IPV6
 	done
 	echo ""
 	echo "What port do you want for OpenVPN?"

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -169,7 +169,7 @@ if [[ -e /etc/openvpn/server.conf ]]; then
 				fi
 				iptables -t nat -D POSTROUTING -o $NIC -s 10.8.0.0/24 -j MASQUERADE
 				if [[ "$IPV6" = 'y' ]]; then
-					ip6tables -t nat -D POSTROUTING -o $NIC -s fd6c:62d9:eb8c::/112 -j MASQUERADE
+					ip6tables -t nat -D POSTROUTING -o $NIC -s fd42:42:42:42::/112 -j MASQUERADE
 				fi
 				iptables-save > $IPTABLES
 				if hash sestatus 2>/dev/null; then
@@ -574,7 +574,7 @@ ifconfig-pool-persist ipp.txt" >> /etc/openvpn/server.conf
 	echo 'push "redirect-gateway def1 bypass-dhcp" '>> /etc/openvpn/server.conf
 
 	if [[ "$IPV6" = 'y' ]]; then
-		echo 'server-ipv6 fd6c:62d9:eb8c::/112
+		echo 'server-ipv6 fd42:42:42:42::/112
 tun-ipv6
 push tun-ipv6
 push "route-ipv6 2000::/3"
@@ -610,7 +610,7 @@ verb 3" >> /etc/openvpn/server.conf
 	# Set NAT for the VPN subnet
 	iptables -t nat -A POSTROUTING -o $NIC -s 10.8.0.0/24 -j MASQUERADE
 	if [[ "$IPV6" = 'y' ]]; then
-		ip6tables -t nat -A POSTROUTING -o $NIC -s fd6c:62d9:eb8c::/112 -j MASQUERADE
+		ip6tables -t nat -A POSTROUTING -o $NIC -s fd42:42:42:42::/112 -j MASQUERADE
 	fi
 	# Save persitent iptables rules
 	iptables-save > $IPTABLES
@@ -649,7 +649,7 @@ verb 3" >> /etc/openvpn/server.conf
 			elif [[ "$PROTOCOL" = 'TCP' ]]; then
 				ip6tables -I INPUT -p tcp --dport $PORT -j ACCEPT
 			fi
-			ip6tables -I FORWARD -s fd6c:62d9:eb8c::/112 -j ACCEPT
+			ip6tables -I FORWARD -s fd42:42:42:42::/112 -j ACCEPT
 			ip6tables -I FORWARD -m state --state RELATED,ESTABLISHED -j ACCEPT
 			# Save persitent OpenVPN rules
 			iptables-save > $IPTABLES


### PR DESCRIPTION
Thanks to @galaxydata (#236)

**This isn't *real* IPv6 support**, but since it's easy to implement, why not support it?

To do:

- [x] Handle all the firewall stuff
- [x] Detect IPv6 connection on the host before asking
- [x] Choose a cool subnet
- [x] Test on multiple OS and providers
- [x] Update README

Note the connection is made via IPv4 and IPv6 settings are pushed **from** the server