### PR TITLE
Add self-hosted DNS resolver (Unbound)

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ The script will ask you which DNS resolvers you want to use when connected to th
 Here are the possibilities :
 
 - Current system resolvers, those that are in `/etc/resolv.conf`
+- Self-hosted resolver thanks to Unbound
 - [Cloudflare](https://1.1.1.1/), recommended, fastest resolvers available (Anycast servers)
 - [Quad9](https://www.quad9.net), recommended, security and privacy oriented, fast worldwide (Anycast servers)
 - [FDN's DNS Servers](http://www.fdn.fr/actions/dns/), recommended if you're in western europe (France)
@@ -106,7 +107,6 @@ Here are the possibilities :
 - [Google Public DNS](https://en.wikipedia.org/wiki/Google_Public_DNS), not recommended, but fast worldwide (Anycast servers)
 - [Yandex Basic DNS](https://dns.yandex.com/), not recommended, but fast in Russia
 - [AdGuard DNS](https://github.com/AdguardTeam/AdguardDNS), located in Russia, blocks ads and trackers
-- Soon : local resolver :D
 
 Any other fast, trustable and neutral servers proposition is welcome.
 

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -355,7 +355,7 @@ if [[ -e /etc/openvpn/server.conf ]]; then
 
 					rm /etc/unbound/${UNBOUND_CONF_D}/openvpn.conf
 
-					read -rp "Do you want to remove Unbound, too? [y/n]: " -e -i n REMOVE
+					read -rp "Do you want to remove Unbound, too? [y/n]: " -e REMOVE
 
 					if [[ "$REMOVE" = 'y' ]]; then
 						if [[ "$OS" = 'debian' ]]; then

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -805,9 +805,6 @@ prefetch: yes' >> /etc/unbound/unbound.conf
 			# Restart Unbound
 			service unbound restart
 
-			# Needed for the chattr command
-			apt-get install -y e2fsprogs
-
 		elif [[ "$OS" = "centos" ]]; then
 			# Install Unbound
 			yum install -y unbound

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -189,9 +189,19 @@ private-address: ::ffff:0:0/96" >> /etc/unbound/unbound.conf
 			if [ -d "/etc/unbound/conf.d" ]; then
 				# Debian / Ubuntu
 				UNBOUND_CONF_D="/etc/unbound/conf.d"
+				if ! grep -qs "^include: \"/etc/unbound/unbound.conf.d/\*.conf\"" /etc/unbound/unbound.conf; then
+					echo 'include: "/etc/unbound/unbound.conf.d/*.conf"' >> /etc/unbound/unbound.conf
+				fi
 			elif [ -d "/etc/unbound/unbound.conf.d" ]; then
 				# CentOS / Fedora
 				UNBOUND_CONF_D="/etc/unbound/unbound.conf.d"
+				if ! grep -qs "^include: /etc/unbound/conf.d/\*.conf" /etc/unbound/unbound.conf; then
+					echo 'include: /etc/unbound/conf.d/*.conf' >> /etc/unbound/unbound.conf
+				fi
+			else
+				UNBOUND_CONF_D="/etc/unbound/conf.d"
+				mkdir -p $UNBOUND_CONF_D
+				echo 'include: "/etc/unbound/unbound.conf.d/*.conf"' >> /etc/unbound/unbound.conf
 			fi
 
 			# Add OpenVPN integration
@@ -346,11 +356,11 @@ if [[ -e /etc/openvpn/server.conf ]]; then
 				if [[ -e /etc/unbound/unbound.conf ]]; then
 
 					if [ -d "/etc/unbound/conf.d" ]; then
-						# Debian / Ubuntu
 						UNBOUND_CONF_D="/etc/unbound/conf.d"
+						sed -i 's|include: \/etc\/unbound\/conf.d\/\*.conf||' /etc/unbound/unbound.conf
 					elif [ -d "/etc/unbound/unbound.conf.d" ]; then
-						# CentOS / Fedora
 						UNBOUND_CONF_D="/etc/unbound/unbound.conf.d"
+						sed -i 's|include: "\/etc\/unbound\/unbound.conf.d\/\*.conf"||' /etc/unbound/unbound.conf
 					fi
 
 					rm ${UNBOUND_CONF_D}/openvpn.conf

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -315,7 +315,7 @@ else
 	echo ""
 	echo "What DNS do you want to use with the VPN?"
 	echo "   1) Current system resolvers (from /etc/resolv.conf)"
-	echo "   2) Local DNS Resolver (Unbound will be installed)"
+	echo "   2) Local DNS Resolver (Unbound will be configured)"
 	echo "   3) Cloudflare (Anycast: worldwide)"
 	echo "   4) Quad9 (Anycast: worldwide)"
 	echo "   5) FDN (France)"

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -225,6 +225,30 @@ if [[ -e /etc/openvpn/server.conf ]]; then
 				done
 				rm -rf /etc/openvpn
 				rm -rf /usr/share/doc/openvpn*
+
+				if [[ -e /etc/unbound/openvpn-server.conf ]]; then
+					# Remove Unbound integration with OpenVPN
+					rm /etc/unbound/openvpn-server.conf
+					sed -i '/openvpn-server.conf/d' /etc/unbound/unbound.conf
+
+					read -rp "Do you want to remove Unbound, too? [y/n]: " -e -i n REMOVE
+
+					if [[ "$REMOVE" = 'y' ]]; then
+						if [[ "$OS" = 'debian' ]]; then
+							apt-get autoremove --purge -y unbound
+						elif [[ "$OS" = 'arch' ]]; then
+							pacman -R unbound --noconfirm
+						else
+							yum remove unbound -y
+						fi
+
+						echo ""
+						echo "Unbound removed!"
+					else
+						echo ""
+						echo "Unbound not removed!"
+					fi
+				fi
 				echo ""
 				echo "OpenVPN removed!"
 			else

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -179,6 +179,7 @@ private-address: ::ffff:0:0/96" >> /etc/unbound/unbound.conf
 		echo "You can allow the script to configure it in order to use it from your OpenVPN clients"
 		echo "We will simply add a second server to /etc/unbound/unbound.conf for the OpenVPN subnet."
 		echo "No changes are made to the current configuration."
+		echo ""
 
 		while [[ $CONTINUE != "y" && $CONTINUE != "n" ]]; do
 			read -rp "Apply configuration changes? [y/n]: " -e CONTINUE

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -112,7 +112,7 @@ prefetch: yes' >> /etc/unbound/unbound.conf
 			yum install -y unbound
 
 			# Configuration
-			echo 'interface: 10.8.0.1' >> /etc/unbound/unbound.conf
+			sed -i 's|# interface: 0.0.0.0$|interface: 10.8.0.1|' /etc/unbound/unbound.conf
 			sed -i 's|# access-control: 127.0.0.0/8 allow|access-control: 10.8.0.1/24 allow|' /etc/unbound/unbound.conf
 			sed -i 's|# hide-identity: no|hide-identity: yes|' /etc/unbound/unbound.conf
 			sed -i 's|# hide-version: no|hide-version: yes|' /etc/unbound/unbound.conf
@@ -123,7 +123,7 @@ prefetch: yes' >> /etc/unbound/unbound.conf
 			dnf install -y unbound
 
 			# Configuration
-			echo 'interface: 10.8.0.1' >> /etc/unbound/unbound.conf
+			sed -i 's|# interface: 0.0.0.0$|interface: 10.8.0.1|' /etc/unbound/unbound.conf
 			sed -i 's|# access-control: 127.0.0.0/8 allow|access-control: 10.8.0.1/24 allow|' /etc/unbound/unbound.conf
 			sed -i 's|# hide-identity: no|hide-identity: yes|' /etc/unbound/unbound.conf
 			sed -i 's|# hide-version: no|hide-version: yes|' /etc/unbound/unbound.conf

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -940,5 +940,3 @@ verb 3" >> /etc/openvpn/client-template.txt
 	echo "If you want to add more clients, you simply need to run this script another time!"
 fi
 exit 0;
-
-

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -181,7 +181,7 @@ private-address: ::ffff:0:0/96" >> /etc/unbound/unbound.conf
 		echo "No other changes are made to the current configuration."
 
 		while [[ $CONTINUE != "y" && $CONTINUE != "n" ]]; do
-			read -rp "Apply configuration changes? [y/n]: " -e local CONTINUE
+			read -rp "Apply configuration changes? [y/n]: " -e CONTINUE
 		done
 
 		if [[ $CONTINUE = "y" ]]; then

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -876,6 +876,10 @@ prefetch: yes' > /etc/unbound/unbound.conf
 			# Start the service
   			systemctl start unbound
 		fi
+
+		# DNS Rebinding fix
+		PRIVATE_ADDRESSES="10.0.0.0/8 172.16.0.0/12 192.168.0.0/16 169.254.0.0/16 127.0.0.0/8"
+		echo "private-address: $PRIVATE_ADDRESSES" >> /etc/unbound/unbound.conf
 	else
 				echo "Unbound is already installed."
 	fi

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -187,22 +187,22 @@ private-address: ::ffff:0:0/96" >> /etc/unbound/unbound.conf
 
 		if [[ $CONTINUE = "y" ]]; then
 
-			if [ -d "/etc/unbound/conf.d" ]; then
+			if [ -d "/etc/unbound/unbound.conf.d" ]; then
 				# Debian / Ubuntu
-				UNBOUND_CONF_D="/etc/unbound/conf.d"
+				UNBOUND_CONF_D="/etc/unbound/unbound.conf.d"
 				if ! grep -qs "^include: \"/etc/unbound/unbound.conf.d/\*.conf\"" /etc/unbound/unbound.conf; then
 					echo 'include: "/etc/unbound/unbound.conf.d/*.conf"' >> /etc/unbound/unbound.conf
 				fi
-			elif [ -d "/etc/unbound/unbound.conf.d" ]; then
+			elif [ -d "/etc/unbound/conf.d" ]; then
 				# CentOS / Fedora
-				UNBOUND_CONF_D="/etc/unbound/unbound.conf.d"
+				UNBOUND_CONF_D="/etc/unbound/conf.d"
 				if ! grep -qs "^include: /etc/unbound/conf.d/\*.conf" /etc/unbound/unbound.conf; then
 					echo 'include: /etc/unbound/conf.d/*.conf' >> /etc/unbound/unbound.conf
 				fi
 			else
 				UNBOUND_CONF_D="/etc/unbound/conf.d"
 				mkdir -p $UNBOUND_CONF_D
-				echo 'include: "/etc/unbound/unbound.conf.d/*.conf"' >> /etc/unbound/unbound.conf
+				echo 'include: "/etc/unbound/conf.d/*.conf"' >> /etc/unbound/unbound.conf
 			fi
 
 			# Add OpenVPN integration

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -176,27 +176,26 @@ private-address: ::ffff:0:0/96" >> /etc/unbound/unbound.conf
 	else
 		echo ""
 		echo "Unbound is already installed."
-		echo "You can allow the script to configure it automatically for OpenVPN integration:"
-		echo "an 'include:' statement will be added to 'unbound.conf' with the necessary changes in a separate 'openvpn-server.conf' file."
-		echo "No other changes are made to the current configuration."
+		echo "You can allow the script to configure it in order to use it from your OpenVPN clients"
+		echo "We will simply add a second server to /etc/unbound/unbound.conf for the OpenVPN subnet."
+		echo "No changes are made to the current configuration."
 
 		while [[ $CONTINUE != "y" && $CONTINUE != "n" ]]; do
 			read -rp "Apply configuration changes? [y/n]: " -e CONTINUE
 		done
 
 		if [[ $CONTINUE = "y" ]]; then
-			# Add include: statement
-			awk '{ print } !flag && /server:/ { print "        include: /etc/unbound/openvpn-server.conf"; flag = 1 }' /etc/unbound/unbound.conf > /etc/unbound/unbound.conf
 
 			# Add OpenVPN integration
-			echo 'interface: 10.8.0.1
-access-control: 10.8.0.1/24 allow' > /etc/unbound/openvpn-server.conf
+			echo 'server:
+	interface: 10.8.0.1
+	access-control: 10.8.0.1/24 allow' >> /etc/unbound/unbound.conf
 
 			# Restart the service
 			systemctl restart unbound
 		else
-			echo "OpenVPN will be configured to use 10.8.0.1 IP for clients DNS"
-			echo "You need to manually configure Unbound to listen on this interface and accept connections from the subnet"
+			echo "OpenVPN clients will be configured to use 10.8.0.1 as DNS resolver."
+			echo "You need to manually configure Unbound to listen on this interface and accept connections from the subnet."
 		fi
 	fi
 }

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -191,6 +191,7 @@ access-control: 10.8.0.1/24 allow' > /etc/unbound/openvpn-server.conf
 		else
 			echo "OpenVPN will be configured to use 10.8.0.1 IP for clients DNS"
 			echo "You need to manually configure Unbound to listen on this interface and accept connections from the subnet"
+		fi
 	fi
 }
 

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -909,6 +909,6 @@ access-control: 10.8.0.1/24 allow' > /etc/unbound/openvpn-server.conf
 			systemctl restart unbound
 		else
 			echo "OpenVPN will be configured to use 10.8.0.1 IP for clients DNS"
-			echo "You need to manually configure Unbound to listen on this interface"
+			echo "You need to manually configure Unbound to listen on this interface and accept connections from the subnet"
 	fi
 }

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -795,7 +795,9 @@ function installLocalDNS () {
 			apt-get install -y unbound
 
 			# Configuration
-			echo 'hide-identity: yes
+			echo 'interface: 10.8.0.1
+access-control: 10.8.0.1/24 allow
+hide-identity: yes
 hide-version: yes
 use-caps-for-id: yes
 prefetch: yes' >> /etc/unbound/unbound.conf
@@ -811,6 +813,8 @@ prefetch: yes' >> /etc/unbound/unbound.conf
 			yum install -y unbound
 
 			# Configuration
+			sed -i 's|# interface: 0.0.0.0|interface: 10.8.0.1' /etc/unbound/unbound.conf
+			sed -i 's|# access-control: 127.0.0.0/8 allow|access-control: 10.8.0.1/24 allow' /etc/unbound/unbound.conf
 			sed -i 's|# hide-identity: no|hide-identity: yes|' /etc/unbound/unbound.conf
 			sed -i 's|# hide-version: no|hide-version: yes|' /etc/unbound/unbound.conf
 			sed -i 's|use-caps-for-id: no|use-caps-for-id: yes|' /etc/unbound/unbound.conf
@@ -826,6 +830,8 @@ prefetch: yes' >> /etc/unbound/unbound.conf
 			dnf install -y unbound
 
 			# Configuration
+			sed -i 's|# interface: 0.0.0.0|interface: 10.8.0.1' /etc/unbound/unbound.conf
+			sed -i 's|# access-control: 127.0.0.0/8 allow|access-control: 10.8.0.1/24 allow' /etc/unbound/unbound.conf
 			sed -i 's|# hide-identity: no|hide-identity: yes|' /etc/unbound/unbound.conf
 			sed -i 's|# hide-version: no|hide-version: yes|' /etc/unbound/unbound.conf
 			sed -i 's|# use-caps-for-id: no|use-caps-for-id: yes|' /etc/unbound/unbound.conf
@@ -852,8 +858,8 @@ prefetch: yes' >> /etc/unbound/unbound.conf
 			echo 'server:
 root-hints: root.hints
 auto-trust-anchor-file: trusted-key.key
-interface: 127.0.0.1
-access-control: 127.0.0.1 allow
+interface: 10.8.0.1
+access-control: 10.8.0.1/24 allow
 port: 53
 do-daemonize: yes
 num-threads: 2

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -95,11 +95,8 @@ function installLocalDNS () {
 	if [[ ! -e /etc/unbound/unbound.conf ]]; then
 
 		if [[ "$OS" = "debian" ]]; then
-			# Install Unbound
-			apt-get update
 			apt-get install -y unbound
 
-			# Configuration
 			echo 'interface: 10.8.0.1
 access-control: 10.8.0.1/24 allow
 hide-identity: yes
@@ -108,7 +105,6 @@ use-caps-for-id: yes
 prefetch: yes' >> /etc/unbound/unbound.conf
 
 		elif [[ "$OS" = "centos" ]]; then
-			# Install Unbound
 			yum install -y unbound
 
 			# Configuration
@@ -119,7 +115,6 @@ prefetch: yes' >> /etc/unbound/unbound.conf
 			sed -i 's|use-caps-for-id: no|use-caps-for-id: yes|' /etc/unbound/unbound.conf
 
 		elif [[ "$OS" = "fedora" ]]; then
-			# Install Unbound
 			dnf install -y unbound
 
 			# Configuration
@@ -430,7 +425,7 @@ else
 	echo ""
 	echo "What DNS do you want to use with the VPN?"
 	echo "   1) Current system resolvers (from /etc/resolv.conf)"
-	echo "   2) Local DNS Resolver (Unbound will be configured)"
+	echo "   2) Self-hosted DNS Resolver (Unbound)"
 	echo "   3) Cloudflare (Anycast: worldwide)"
 	echo "   4) Quad9 (Anycast: worldwide)"
 	echo "   5) FDN (France)"
@@ -748,6 +743,7 @@ ifconfig-pool-persist ipp.txt" >> /etc/openvpn/server.conf
 		done
 		;;
 		2)
+		# Install Unbound
 		installLocalDNS
 		echo 'push "dhcp-option DNS 10.8.0.1"' >> /etc/openvpn/server.conf
 		;;

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -189,7 +189,7 @@ private-address: ::ffff:0:0/96" >> /etc/unbound/unbound.conf
 			# Add OpenVPN integration
 			echo 'server:
 	interface: 10.8.0.1
-	access-control: 10.8.0.1/24 allow' >> /etc/unbound/unbound.conf
+	access-control: 10.8.0.1/24 allow' >> /etc/unbound/conf.d/openvpn.conf
 
 			# Restart the service
 			systemctl restart unbound

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -291,16 +291,17 @@ else
 	echo ""
 	echo "What DNS do you want to use with the VPN?"
 	echo "   1) Current system resolvers (from /etc/resolv.conf)"
-	echo "   2) Cloudflare (Anycast: worldwide)"
-	echo "   3) Quad9 (Anycast: worldwide)"
-	echo "   4) FDN (France)"
-	echo "   5) DNS.WATCH (Germany)"
-	echo "   6) OpenDNS (Anycast: worldwide)"
-	echo "   7) Google (Anycast: worldwide)"
-	echo "   8) Yandex Basic (Russia)"
-	echo "   9) AdGuard DNS (Russia)"
-	until [[ "$DNS" =~ ^[0-9]+$ ]] && [ "$DNS" -ge 1 -a "$DNS" -le 9 ]; do
-		read -rp "DNS [1-9]: " -e -i 1 DNS
+	echo "   2) Local DNS Resolver (Unbound will be installed)"
+	echo "   3) Cloudflare (Anycast: worldwide)"
+	echo "   4) Quad9 (Anycast: worldwide)"
+	echo "   5) FDN (France)"
+	echo "   6) DNS.WATCH (Germany)"
+	echo "   7) OpenDNS (Anycast: worldwide)"
+	echo "   8) Google (Anycast: worldwide)"
+	echo "   9) Yandex Basic (Russia)"
+	echo "   10) AdGuard DNS (Russia)"
+	until [[ "$DNS" =~ ^[0-10]+$ ]] && [ "$DNS" -ge 1 -a "$DNS" -le 10 ]; do
+		read -rp "DNS [1-10]: " -e -i 1 DNS
 	done
 	echo ""
 	echo "See https://github.com/Angristan/OpenVPN-install#encryption to learn more about "
@@ -591,35 +592,38 @@ ifconfig-pool-persist ipp.txt" >> /etc/openvpn/server.conf
 			echo "push \"dhcp-option DNS $line\"" >> /etc/openvpn/server.conf
 		done
 		;;
-		2) # Cloudflare
+		2)
+
+		;;
+		3) # Cloudflare
 		echo 'push "dhcp-option DNS 1.0.0.1"' >> /etc/openvpn/server.conf
 		echo 'push "dhcp-option DNS 1.1.1.1"' >> /etc/openvpn/server.conf	
 		;;
-		3) # Quad9
+		4) # Quad9
 		echo 'push "dhcp-option DNS 9.9.9.9"' >> /etc/openvpn/server.conf
 		echo 'push "dhcp-option DNS 149.112.112.112"' >> /etc/openvpn/server.conf
 		;;
-		4) # FDN
+		5) # FDN
 		echo 'push "dhcp-option DNS 80.67.169.40"' >> /etc/openvpn/server.conf
 		echo 'push "dhcp-option DNS 80.67.169.12"' >> /etc/openvpn/server.conf
 		;;
-		5) # DNS.WATCH
+		6) # DNS.WATCH
 		echo 'push "dhcp-option DNS 84.200.69.80"' >> /etc/openvpn/server.conf
 		echo 'push "dhcp-option DNS 84.200.70.40"' >> /etc/openvpn/server.conf
 		;;
-		6) # OpenDNS
+		7) # OpenDNS
 		echo 'push "dhcp-option DNS 208.67.222.222"' >> /etc/openvpn/server.conf
 		echo 'push "dhcp-option DNS 208.67.220.220"' >> /etc/openvpn/server.conf
 		;;
-		7) # Google
+		8) # Google
 		echo 'push "dhcp-option DNS 8.8.8.8"' >> /etc/openvpn/server.conf
 		echo 'push "dhcp-option DNS 8.8.4.4"' >> /etc/openvpn/server.conf
 		;;
-		8) # Yandex Basic
+		9) # Yandex Basic
 		echo 'push "dhcp-option DNS 77.88.8.8"' >> /etc/openvpn/server.conf
 		echo 'push "dhcp-option DNS 77.88.8.1"' >> /etc/openvpn/server.conf
 		;;
-		9) # AdGuard DNS
+		10) # AdGuard DNS
 		echo 'push "dhcp-option DNS 176.103.130.130"' >> /etc/openvpn/server.conf
 		echo 'push "dhcp-option DNS 176.103.130.131"' >> /etc/openvpn/server.conf
 		;;

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -192,7 +192,7 @@ private-address: ::ffff:0:0/96" >> /etc/unbound/unbound.conf
 			elif [ -d "/etc/unbound/unbound.conf.d" ]; then
 				# CentOS / Fedora
 				UNBOUND_CONF_D="/etc/unbound/unbound.conf.d"
-			else
+			fi
 
 			# Add OpenVPN integration
 			echo 'server:

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -365,9 +365,11 @@ if [[ -e /etc/openvpn/server.conf ]]; then
 
 					rm ${UNBOUND_CONF_D}/openvpn.conf
 
-					read -rp "Do you want to remove Unbound, too? [y/n]: " -e REMOVE
+					until [[ $REMOVE_UNBOUND == "y" || $REMOVE_UNBOUND == "n" ]]; do
+						read -rp "Do you want to remove Unbound, too? [y/n]: " -e REMOVE_UNBOUND
+					done
 
-					if [[ "$REMOVE" = 'y' ]]; then
+					if [[ "$REMOVE_UNBOUND" = 'y' ]]; then
 						if [[ "$OS" = 'debian' ]]; then
 							apt-get autoremove --purge -y unbound
 						elif [[ "$OS" = 'arch' ]]; then

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -186,10 +186,18 @@ private-address: ::ffff:0:0/96" >> /etc/unbound/unbound.conf
 
 		if [[ $CONTINUE = "y" ]]; then
 
+			if [ -d "/etc/unbound/conf.d" ]; then
+				# Debian / Ubuntu
+				UNBOUND_CONF_D="/etc/unbound/conf.d"
+			elif [ -d "/etc/unbound/unbound.conf.d" ]; then
+				# CentOS / Fedora
+				UNBOUND_CONF_D="/etc/unbound/unbound.conf.d"
+			else
+
 			# Add OpenVPN integration
 			echo 'server:
 	interface: 10.8.0.1
-	access-control: 10.8.0.1/24 allow' >> /etc/unbound/conf.d/openvpn.conf
+	access-control: 10.8.0.1/24 allow' >> /etc/unbound/${UNBOUND_CONF_D}/openvpn.conf
 
 			# Restart the service
 			systemctl restart unbound
@@ -335,10 +343,17 @@ if [[ -e /etc/openvpn/server.conf ]]; then
 				rm -rf /etc/openvpn
 				rm -rf /usr/share/doc/openvpn*
 
-				if [[ -e /etc/unbound/openvpn-server.conf ]]; then
-					# Remove Unbound integration with OpenVPN
-					rm /etc/unbound/openvpn-server.conf
-					sed -i '/openvpn-server.conf/d' /etc/unbound/unbound.conf
+				if [[ -e /etc/unbound/unbound.conf ]]; then
+
+					if [ -d "/etc/unbound/conf.d" ]; then
+						# Debian / Ubuntu
+						UNBOUND_CONF_D="/etc/unbound/conf.d"
+					elif [ -d "/etc/unbound/unbound.conf.d" ]; then
+						# CentOS / Fedora
+						UNBOUND_CONF_D="/etc/unbound/unbound.conf.d"
+					fi
+
+					rm /etc/unbound/${UNBOUND_CONF_D}/openvpn.conf
 
 					read -rp "Do you want to remove Unbound, too? [y/n]: " -e -i n REMOVE
 

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -324,7 +324,7 @@ else
 	echo "   8) Google (Anycast: worldwide)"
 	echo "   9) Yandex Basic (Russia)"
 	echo "   10) AdGuard DNS (Russia)"
-	until [[ "$DNS" =~ ^[0-10]+$ ]] && [ "$DNS" -ge 1 -a "$DNS" -le 10 ]; do
+	until [[ "$DNS" =~ ^[0-9]+$ ]] && [ "$DNS" -ge 1 -a "$DNS" -le 10 ]; do
 		read -rp "DNS [1-10]: " -e -i 1 DNS
 	done
 	echo ""

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -197,7 +197,7 @@ private-address: ::ffff:0:0/96" >> /etc/unbound/unbound.conf
 			# Add OpenVPN integration
 			echo 'server:
 	interface: 10.8.0.1
-	access-control: 10.8.0.1/24 allow' >> /etc/unbound/${UNBOUND_CONF_D}/openvpn.conf
+	access-control: 10.8.0.1/24 allow' >> ${UNBOUND_CONF_D}/openvpn.conf
 
 			# Restart the service
 			systemctl restart unbound
@@ -353,7 +353,7 @@ if [[ -e /etc/openvpn/server.conf ]]; then
 						UNBOUND_CONF_D="/etc/unbound/unbound.conf.d"
 					fi
 
-					rm /etc/unbound/${UNBOUND_CONF_D}/openvpn.conf
+					rm ${UNBOUND_CONF_D}/openvpn.conf
 
 					read -rp "Do you want to remove Unbound, too? [y/n]: " -e REMOVE
 

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -192,7 +192,7 @@ private-address: 169.254.0.0/16
 private-address: fd00::/8
 private-address: fe80::/10
 private-address: 127.0.0.0/8
-private-address: ::ffff:0:0/96' >> /etc/unbound/openvpn.conf
+private-address: ::ffff:0:0/96' > /etc/unbound/openvpn.conf
 
 		# Restart the service
 		systemctl restart unbound

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -367,7 +367,9 @@ if [[ -e /etc/openvpn/server.conf ]]; then
 
 					until [[ $REMOVE_UNBOUND == "y" || $REMOVE_UNBOUND == "n" ]]; do
 						echo ""
-						read -rp "Do you want to remove Unbound, too? [y/n]: " -e REMOVE_UNBOUND
+						echo "If you were already using Unbound before installing OpenVPN, I removed the configuration related to OpenVPN."
+						echo "You can keep using Unbound as before."
+						read -rp "Do you want to completely remove Unbound? [y/n]: " -e REMOVE_UNBOUND
 					done
 
 					if [[ "$REMOVE_UNBOUND" = 'y' ]]; then

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -112,8 +112,8 @@ prefetch: yes' >> /etc/unbound/unbound.conf
 			yum install -y unbound
 
 			# Configuration
-			sed -i 's|# interface: 0.0.0.0|interface: 10.8.0.1' /etc/unbound/unbound.conf
-			sed -i 's|# access-control: 127.0.0.0/8 allow|access-control: 10.8.0.1/24 allow' /etc/unbound/unbound.conf
+			echo 'interface: 10.8.0.1' >> /etc/unbound/unbound.conf
+			sed -i 's|# access-control: 127.0.0.0/8 allow|access-control: 10.8.0.1/24 allow|' /etc/unbound/unbound.conf
 			sed -i 's|# hide-identity: no|hide-identity: yes|' /etc/unbound/unbound.conf
 			sed -i 's|# hide-version: no|hide-version: yes|' /etc/unbound/unbound.conf
 			sed -i 's|use-caps-for-id: no|use-caps-for-id: yes|' /etc/unbound/unbound.conf
@@ -123,8 +123,8 @@ prefetch: yes' >> /etc/unbound/unbound.conf
 			dnf install -y unbound
 
 			# Configuration
-			sed -i 's|# interface: 0.0.0.0|interface: 10.8.0.1' /etc/unbound/unbound.conf
-			sed -i 's|# access-control: 127.0.0.0/8 allow|access-control: 10.8.0.1/24 allow' /etc/unbound/unbound.conf
+			echo 'interface: 10.8.0.1' >> /etc/unbound/unbound.conf
+			sed -i 's|# access-control: 127.0.0.0/8 allow|access-control: 10.8.0.1/24 allow|' /etc/unbound/unbound.conf
 			sed -i 's|# hide-identity: no|hide-identity: yes|' /etc/unbound/unbound.conf
 			sed -i 's|# hide-version: no|hide-version: yes|' /etc/unbound/unbound.conf
 			sed -i 's|# use-caps-for-id: no|use-caps-for-id: yes|' /etc/unbound/unbound.conf

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -363,9 +363,10 @@ if [[ -e /etc/openvpn/server.conf ]]; then
 						sed -i 's|include: "\/etc\/unbound\/unbound.conf.d\/\*.conf"||' /etc/unbound/unbound.conf
 					fi
 
-					rm ${UNBOUND_CONF_D}/openvpn.conf
+					rm ${UNBOUND_CONF_D}/openvpn.conf >> /dev/null 2>&1
 
 					until [[ $REMOVE_UNBOUND == "y" || $REMOVE_UNBOUND == "n" ]]; do
+						echo ""
 						read -rp "Do you want to remove Unbound, too? [y/n]: " -e REMOVE_UNBOUND
 					done
 

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -441,7 +441,7 @@ else
 	echo "   10) AdGuard DNS (Russia)"
 	until [[ "$DNS" =~ ^[0-9]+$ ]] && [ "$DNS" -ge 1 -a "$DNS" -le 10 ]; do
 		read -rp "DNS [1-10]: " -e -i 1 DNS
-			if [[ $DNS == 2 ]] && [[ ! -e /etc/unbound/unbound.conf ]]; then
+			if [[ $DNS == 2 ]] && [[ -e /etc/unbound/unbound.conf ]]; then
 				echo ""
 				echo "Unbound is already installed."
 				echo "You can allow the script to configure it in order to use it from your OpenVPN clients"
@@ -454,6 +454,7 @@ else
 				done
 				if [[ $CONTINUE = "n" ]];then
 					DNS=""
+					CONTINUE=""
 				fi
 			fi
 	done

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -863,6 +863,28 @@ prefetch: yes' > /etc/unbound/unbound.conf
 		# Restart the service
 		systemctl restart unbound
 	else
-				echo "Unbound is already installed."
+		echo ""
+		echo "Unbound is already installed."
+		echo "You can allow the script to configure it automatically for OpenVPN integration:"
+		echo "an `include:` statement will be added to `unbound.conf` with the necessary changes in a separate `openvpn-server.conf` file."
+		echo "No other changes are made to the current configuration."
+
+		while [[ $CONTINUE != "y" && $CONTINUE != "n" ]]; do
+			read -rp "Apply configuration changes? [y/n]: " -e local CONTINUE
+		done
+
+		if [[ $CONTINUE = "y" ]]; then
+			# Add include: statement
+			awk '{ print } !flag && /server:/ { print "        include: /etc/unbound/openvpn-server.conf"; flag = 1 }' /etc/unbound/unbound.conf > /etc/unbound/unbound.conf
+
+			# Add OpenVPN integration
+			echo 'interface: 10.8.0.1
+access-control: 10.8.0.1/24 allow' > /etc/unbound/openvpn-server.conf
+
+			# Restart the service
+			systemctl restart unbound
+		else
+			echo "OpenVPN will be configured to use 10.8.0.1 IP for clients DNS"
+			echo "You need to manually configure Unbound to listen on this interface"
 	fi
 }

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -177,7 +177,7 @@ private-address: ::ffff:0:0/96" >> /etc/unbound/unbound.conf
 		echo ""
 		echo "Unbound is already installed."
 		echo "You can allow the script to configure it automatically for OpenVPN integration:"
-		echo "an `include:` statement will be added to `unbound.conf` with the necessary changes in a separate `openvpn-server.conf` file."
+		echo "an 'include:' statement will be added to 'unbound.conf' with the necessary changes in a separate 'openvpn-server.conf' file."
 		echo "No other changes are made to the current configuration."
 
 		while [[ $CONTINUE != "y" && $CONTINUE != "n" ]]; do

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -802,9 +802,6 @@ hide-version: yes
 use-caps-for-id: yes
 prefetch: yes' >> /etc/unbound/unbound.conf
 
-			# Restart Unbound
-			service unbound restart
-
 		elif [[ "$OS" = "centos" ]]; then
 			# Install Unbound
 			yum install -y unbound
@@ -816,12 +813,6 @@ prefetch: yes' >> /etc/unbound/unbound.conf
 			sed -i 's|# hide-version: no|hide-version: yes|' /etc/unbound/unbound.conf
 			sed -i 's|use-caps-for-id: no|use-caps-for-id: yes|' /etc/unbound/unbound.conf
 
-			# Enable service at boot
-			systemctl enable unbound
-
-			# Start the service
-			systemctl start unbound
-
 		elif [[ "$OS" = "fedora" ]]; then
 			# Install Unbound
 			dnf install -y unbound
@@ -832,12 +823,6 @@ prefetch: yes' >> /etc/unbound/unbound.conf
 			sed -i 's|# hide-identity: no|hide-identity: yes|' /etc/unbound/unbound.conf
 			sed -i 's|# hide-version: no|hide-version: yes|' /etc/unbound/unbound.conf
 			sed -i 's|# use-caps-for-id: no|use-caps-for-id: yes|' /etc/unbound/unbound.conf
-
-			# Enable service at boot
-			systemctl enable unbound
-
-			# Start the service
-			systemctl start unbound
 
 		elif [[ "$OS" = "arch" ]]; then
 			# Install Unbound
@@ -866,17 +851,17 @@ hide-identity: yes
 hide-version: yes
 qname-minimisation: yes
 prefetch: yes' > /etc/unbound/unbound.conf
-
-			# Enable service at boot
-			systemctl enable unbound
-
-			# Start the service
-  			systemctl start unbound
 		fi
 
 		# DNS Rebinding fix
 		PRIVATE_ADDRESSES="10.0.0.0/8 172.16.0.0/12 192.168.0.0/16 169.254.0.0/16 127.0.0.0/8"
 		echo "private-address: $PRIVATE_ADDRESSES" >> /etc/unbound/unbound.conf
+
+		# Enable service at boot
+		systemctl enable unbound
+
+		# Restart the service
+		systemctl restart unbound
 	else
 				echo "Unbound is already installed."
 	fi

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -340,9 +340,10 @@ if [[ -e /etc/openvpn/server.conf ]]; then
 
 				if [[ -e /etc/unbound/openvpn.conf ]]; then
 
+					# Remove OpenVPN-related config
 					sed -i 's|include: \/etc\/unbound\/openvpn.conf||' /etc/unbound/unbound.conf
-
-					rm /etc/openvpn/openvpn.conf
+					rm /etc/unbound/openvpn.conf
+					systemctl restart unbound
 
 					until [[ $REMOVE_UNBOUND == "y" || $REMOVE_UNBOUND == "n" ]]; do
 						echo ""

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -187,28 +187,12 @@ private-address: ::ffff:0:0/96" >> /etc/unbound/unbound.conf
 
 		if [[ $CONTINUE = "y" ]]; then
 
-			if [ -d "/etc/unbound/unbound.conf.d" ]; then
-				# Debian / Ubuntu
-				UNBOUND_CONF_D="/etc/unbound/unbound.conf.d"
-				if ! grep -qs "^include: \"/etc/unbound/unbound.conf.d/\*.conf\"" /etc/unbound/unbound.conf; then
-					echo 'include: "/etc/unbound/unbound.conf.d/*.conf"' >> /etc/unbound/unbound.conf
-				fi
-			elif [ -d "/etc/unbound/conf.d" ]; then
-				# CentOS / Fedora
-				UNBOUND_CONF_D="/etc/unbound/conf.d"
-				if ! grep -qs "^include: /etc/unbound/conf.d/\*.conf" /etc/unbound/unbound.conf; then
-					echo 'include: /etc/unbound/conf.d/*.conf' >> /etc/unbound/unbound.conf
-				fi
-			else
-				UNBOUND_CONF_D="/etc/unbound/conf.d"
-				mkdir -p $UNBOUND_CONF_D
-				echo 'include: "/etc/unbound/conf.d/*.conf"' >> /etc/unbound/unbound.conf
-			fi
+			echo 'include: /etc/unbound/openvpn.conf' >> /etc/unbound/unbound.conf
 
 			# Add OpenVPN integration
 			echo 'server:
 	interface: 10.8.0.1
-	access-control: 10.8.0.1/24 allow' >> ${UNBOUND_CONF_D}/openvpn.conf
+	access-control: 10.8.0.1/24 allow' >> /etc/unbound/openvpn.conf
 
 			# Restart the service
 			systemctl restart unbound
@@ -354,17 +338,11 @@ if [[ -e /etc/openvpn/server.conf ]]; then
 				rm -rf /etc/openvpn
 				rm -rf /usr/share/doc/openvpn*
 
-				if [[ -e /etc/unbound/unbound.conf ]]; then
+				if [[ -e /etc/unbound/openvpn.conf ]]; then
 
-					if [ -d "/etc/unbound/conf.d" ]; then
-						UNBOUND_CONF_D="/etc/unbound/conf.d"
-						sed -i 's|include: \/etc\/unbound\/conf.d\/\*.conf||' /etc/unbound/unbound.conf
-					elif [ -d "/etc/unbound/unbound.conf.d" ]; then
-						UNBOUND_CONF_D="/etc/unbound/unbound.conf.d"
-						sed -i 's|include: "\/etc\/unbound\/unbound.conf.d\/\*.conf"||' /etc/unbound/unbound.conf
-					fi
+					sed -i 's|include: \/etc\/unbound\/openvpn.conf||' /etc/unbound/unbound.conf
 
-					rm ${UNBOUND_CONF_D}/openvpn.conf >> /dev/null 2>&1
+					rm /etc/openvpn/openvpn.conf
 
 					until [[ $REMOVE_UNBOUND == "y" || $REMOVE_UNBOUND == "n" ]]; do
 						echo ""

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -159,8 +159,14 @@ prefetch: yes' > /etc/unbound/unbound.conf
 		fi
 
 		# DNS Rebinding fix
-		PRIVATE_ADDRESSES="10.0.0.0/8 172.16.0.0/12 192.168.0.0/16 169.254.0.0/16 127.0.0.0/8"
-		echo "private-address: $PRIVATE_ADDRESSES" >> /etc/unbound/unbound.conf
+		echo "private-address: 10.0.0.0/8
+private-address: 172.16.0.0/12
+private-address: 192.168.0.0/16
+private-address: 169.254.0.0/16
+private-address: fd00::/8
+private-address: fe80::/10
+private-address: 127.0.0.0/8
+private-address: ::ffff:0:0/96" >> /etc/unbound/unbound.conf
 
 		# Enable service at boot
 		systemctl enable unbound

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -158,8 +158,9 @@ qname-minimisation: yes
 prefetch: yes' > /etc/unbound/unbound.conf
 		fi
 
-		# DNS Rebinding fix
-		echo "private-address: 10.0.0.0/8
+if [[ ! "$OS" =~ (fedora|centos) ]];then
+  # DNS Rebinding fix
+  echo "private-address: 10.0.0.0/8
 private-address: 172.16.0.0/12
 private-address: 192.168.0.0/16
 private-address: 169.254.0.0/16
@@ -167,6 +168,7 @@ private-address: fd00::/8
 private-address: fe80::/10
 private-address: 127.0.0.0/8
 private-address: ::ffff:0:0/96" >> /etc/unbound/unbound.conf
+fi
 
 		# Enable service at boot
 		systemctl enable unbound


### PR DESCRIPTION
Added option for installing and configuring Unbound as a recursive resolver. Fix #5.

Notes:
- Option added as a function for easier integration when refactoring branch is merged.
- Changes are a backport of @angristan local-dns-resolver repository.
- ~~Handler when Unbound is already installed is WIP.~~
- I didn't do any test.
- Feedback and ideas are appreciated. 