### PR TITLE
Rework iptables handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,6 @@ The script is made to work on these OS and architectures :
 
 - **Debian 8** (i386, amd64)
 - **Debian 9** (i386, amd64, armhf, arm64)
-- **Ubuntu 14.04 LTS** (i386, amd64)
 - **Ubuntu 16.04 LTS** (i386, amd64, armhf)
 - **Ubuntu 17.10** (i386, amd64, armhf, arm64)
 - **Ubuntu 18.04 LTS** (i386, amd64, armhf, arm64)

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -541,10 +541,6 @@ else
 			yum install epel-release -y
 		fi
 		yum install openvpn iptables openssl wget ca-certificates curl -y
-
-		# Disable firewalld to allow iptables to start upon reboot
-		# systemctl disable firewalld
-		# systemctl mask firewalld
 	fi
 
 	# Install iptables service

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -549,6 +549,7 @@ else
 	# Script to add rules
 	echo "#!/bin/sh
 iptables -t nat -A POSTROUTING -s 10.8.0.0/24 -o eth0 -j MASQUERADE
+iptables -A INPUT -i tun0 -j ACCEPT
 iptables -A FORWARD -i eth0 -o tun0 -j ACCEPT
 iptables -A FORWARD -i tun0 -o eth0 -j ACCEPT" > /etc/iptables/add-openvpn-rules.sh
 
@@ -560,6 +561,7 @@ iptables -A FORWARD -i tun0 -o eth0 -j ACCEPT" > /etc/iptables/add-openvpn-rules
 
 	if [[ "$IPV6" = 'y' ]]; then
 		echo "ip6tables -t nat -A POSTROUTING -s fd42:42:42:42::/112 -o eth0 -j MASQUERADE
+ip6tables -A INPUT -i tun0 -j ACCEPT
 ip6tables -A FORWARD -i eth0 -o tun0 -j ACCEPT
 ip6tables -A FORWARD -i tun0 -o eth0 -j ACCEPT" >> /etc/iptables/add-openvpn-rules.sh
 	fi
@@ -567,6 +569,7 @@ ip6tables -A FORWARD -i tun0 -o eth0 -j ACCEPT" >> /etc/iptables/add-openvpn-rul
 	# Script to remove rules
 	echo "#!/bin/sh
 iptables -t nat -D POSTROUTING -s 10.8.0.0/24 -o eth0 -j MASQUERADE
+iptables -D INPUT -i tun0 -j ACCEPT
 iptables -D FORWARD -i eth0 -o tun0 -j ACCEPT
 iptables -D FORWARD -i tun0 -o eth0 -j ACCEPT" > /etc/iptables/rm-openvpn-rules.sh
 
@@ -578,6 +581,7 @@ iptables -D FORWARD -i tun0 -o eth0 -j ACCEPT" > /etc/iptables/rm-openvpn-rules.
 
 	if [[ "$IPV6" = 'y' ]]; then
 		echo "ip6tables -t nat -D POSTROUTING -s fd42:42:42:42::/112 -o eth0 -j MASQUERADE
+ip6tables -D INPUT -i tun0 -j ACCEPT
 ip6tables -D FORWARD -i eth0 -o tun0 -j ACCEPT
 ip6tables -D FORWARD -i tun0 -o eth0 -j ACCEPT" >> /etc/iptables/rm-openvpn-rules.sh
 	fi


### PR DESCRIPTION
The way we handled iptables rules was pretty messy. 

We switched from rc.local to systemd a while ago: https://github.com/angristan/openvpn-install/pull/83.

But it was still confusing and messed too much with the system since we flushed all the rules. Also it wasn't always working after a reboot, and everything wasn't removed after an uninstallation.

I reworked all of this. Now we have:

- A script that adds the needed rules
- A script that remove these rules
- A systemd service to manage these scripts
- During install and boot, the service executes the script that adds the rules
- During removal, the service executes the script that removes the rules, and then both are removed

We don't touch the rest of the rules nor the policies anymore. I made sure that the rules are working at boot and that everything we added is removed when removing OpenVPN.

**TL;DR:** It's simpler, unobtrusive, works after reboots, and is cleaned after removal.