### PR TITLE
Use ping -6 instead of ping6

### DIFF
--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -211,7 +211,7 @@ function installQuestions () {
 	echo ""
 	echo "Checking for IPv6 connectivity..."
 	echo ""
-	if ping6 -c4 ipv6.google.com > /dev/null 2>&1; then
+	if ping -6 -c4 ipv6.google.com > /dev/null 2>&1; then
 		echo "Your host appears to have IPv6 connectivity."
 		SUGGESTION="y"
 	else


### PR DESCRIPTION
the binary ping6 isn't available/installed by default on Arch Linux.
Thus I've added the normal ping command with the -6 flag for IPv6 ICMP.

