### PR TITLE
Listen on a specific IPv4

### DIFF
--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -660,6 +660,7 @@ function installOpenVPN () {
 	chmod 644 /etc/openvpn/crl.pem
 
 	# Generate server.conf
+	echo "local $IP" >> /etc/openvpn/server.conf
 	echo "port $PORT" > /etc/openvpn/server.conf
 	if [[ "$IPV6_SUPPORT" = 'n' ]]; then
 		echo "proto $PROTOCOL" >> /etc/openvpn/server.conf


### PR DESCRIPTION
Needed if you have more than one IPv4. Just listen on the configured IP on the install.
Tested in my environment.
I have apache server running on one interface with port 443. So its not bindable there. I have bought a second IP. Now OpenVPN needs to know which IP he should bind and not every. So simply setting it in the config. Without this I couldn't connect. Edited config and worked fine for me.