### PR TITLE
Binding server to a specific IP address

### DIFF
--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -673,7 +673,8 @@ function installOpenVPN () {
 		echo "proto ${PROTOCOL}6" >> /etc/openvpn/server.conf
 	fi
 
-	echo "dev tun
+	echo "local $IP
+dev tun
 user nobody
 group $NOGROUP
 persist-key


### PR DESCRIPTION
The server may have multiple network interfaces or multiple IP addresses on a same network interface.

On the server configuration, by adding `local $IP` option, it specifies to bind on the IP address `$IP`.

Use case example:
- the server has 2 public IPs
- a web server is listening on the first IP address on TCP/443
- an openvpn server is listening on the second IP address on TCP/443