### PR TITLE
Add connection to server through IPv6 interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This script will let you setup your own secure VPN server in just a few seconds.
 First, get the script and make it executable :
 
 ```bash
-curl -O https://raw.githubusercontent.com/Angristan/openvpn-install/master/openvpn-install.sh
+curl -O https://raw.githubusercontent.com/tuckyapps/openvpn-install/master/openvpn-install.sh
 chmod +x openvpn-install.sh
 ```
 
@@ -83,7 +83,7 @@ Since 2016, the two scripts have diverged and are not alike anymore, especially 
 
 ## FAQ
 
-**LOOK AT THE [WIKI](https://github.com/angristan/openvpn-install/wiki/FAQ) FOR MORE INFORMATION. PLEASE READ BOTH BEFORE OPENING AN ISSUE.**
+**LOOK AT THE [WIKI](https://github.com/tuckyapps/openvpn-install/wiki/FAQ) FOR MORE INFORMATION. PLEASE READ BOTH BEFORE OPENING AN ISSUE.**
 
 **PLEASE do net send me emails or private messages asking for help.** The only place to get help is the issues. Other people may be able to help and in the future, other users may also run into the same issue as you.
 
@@ -269,6 +269,6 @@ You can [say thanks](https://saythanks.io/to/Angristan) if you want!
 
 ## Credits & Licence
 
-Many thanks to the [contributors](https://github.com/Angristan/OpenVPN-install/graphs/contributors) and Nyr's original work.
+Many thanks to the [contributors](https://github.com/tuckyapps/OpenVPN-install/graphs/contributors) and Nyr's original work.
 
-This project is under the [MIT Licence](https://raw.githubusercontent.com/Angristan/openvpn-install/master/LICENSE)
+This project is under the [MIT Licence](https://raw.githubusercontent.com/tuckyapps/openvpn-install/master/LICENSE)

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ If you have any question, head to the [FAQ](#faq) first.
 - Choice to use a self-hosted resolver with Unbound (supports already existing Unbound installations)
 - Choice between TCP and UDP
 - NATed IPv6 support
+- Connection to openvpn server through IPv6 interface
 - Compression disabled by default to prevent VORACLE. LZ4 and LZ0 algorithms available otherwise.
 - Unprivileged mode: run as `nobody`/`nogroup`
 - Block DNS leaks on Windows 10

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # openvpn-install
 
-[![GitLab CI](https://gitlab.com/tuckyapps/openvpn-install/badges/master/pipeline.svg)](https://gitlab.com/angristan/openvpn-install/pipelines)
-
 OpenVPN installer for Debian, Ubuntu, Fedora, CentOS and Arch Linux.
 
 This script will let you setup your own secure VPN server in just a few seconds.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # openvpn-install
 
-[![GitLab CI](https://gitlab.com/angristan/openvpn-install/badges/master/pipeline.svg)](https://gitlab.com/angristan/openvpn-install/pipelines)
+[![GitLab CI](https://gitlab.com/tuckyapps/openvpn-install/badges/master/pipeline.svg)](https://gitlab.com/angristan/openvpn-install/pipelines)
 
 OpenVPN installer for Debian, Ubuntu, Fedora, CentOS and Arch Linux.
 

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Secure OpenVPN server installer for Debian, Ubuntu, CentOS, Amazon Linux 2, Fedora and Arch Linux
-# https://github.com/tuckyapps/openvpn-install
+# https://github.com/angristan/openvpn-install
 
 function isRoot () {
 	if [ "$EUID" -ne 0 ]; then
@@ -193,7 +193,7 @@ private-address: ::ffff:0:0/96' > /etc/unbound/openvpn.conf
 
 function installQuestions () {
 	echo "Welcome to the OpenVPN installer!"
-	echo "The git repository is available at: https://github.com/tuckyapps/openvpn-install"
+	echo "The git repository is available at: https://github.com/angristan/openvpn-install"
 	echo ""
 
 	echo "I need to ask you a few questions before starting the setup."
@@ -365,7 +365,7 @@ function installQuestions () {
 	echo "Do you want to customize encryption settings?"
 	echo "Unless you know what you're doing, you should stick with the default parameters provided by the script."
 	echo "Note that whatever you choose, all the choices presented in the script are safe. (Unlike OpenVPN's defaults)"
-	echo "See https://github.com/tuckyapps/openvpn-install#security-and-encryption to learn more."
+	echo "See https://github.com/angristan/openvpn-install#security-and-encryption to learn more."
 	echo ""
 	until [[ $CUSTOMIZE_ENC =~ (y|n) ]]; do
 		read -rp "Customize encryption settings? [y/n]: " -e -i n CUSTOMIZE_ENC
@@ -1233,7 +1233,7 @@ function removeOpenVPN () {
 function manageMenu () {
 	clear
 	echo "Welcome to OpenVPN-install!"
-	echo "The git repository is available at: https://github.com/tuckyapps/openvpn-install"
+	echo "The git repository is available at: https://github.com/angristan/openvpn-install"
 	echo ""
 	echo "It looks like OpenVPN is already installed."
 	echo ""

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Secure OpenVPN server installer for Debian, Ubuntu, CentOS, Fedora and Arch Linux
-# https://github.com/angristan/openvpn-install
+# https://github.com/tuckyapps/openvpn-install
 
 function isRoot () {
 	if [ "$EUID" -ne 0 ]; then
@@ -186,7 +186,7 @@ private-address: ::ffff:0:0/96' > /etc/unbound/openvpn.conf
 
 function installQuestions () {
 	echo "Welcome to the OpenVPN installer!"
-	echo "The git repository is available at: https://github.com/angristan/openvpn-install"
+	echo "The git repository is available at: https://github.com/tuckyapps/openvpn-install"
 	echo ""
 
 	echo "I need to ask you a few questions before starting the setup."
@@ -229,7 +229,6 @@ function installQuestions () {
 	until [[ $IPV6_SUPPORT =~ (y|n) ]]; do
 		read -rp "Do you want to enable IPv6 support (NAT)? [y/n]: " -e -i $SUGGESTION IPV6_SUPPORT
 	done
-    echo ""
     
     # Ask the user for its public IPv6 address.
     if [[ "$IPV6_SUPPORT" = 'y' ]]; then
@@ -341,7 +340,7 @@ function installQuestions () {
 	echo "Do you want to customize encryption settings?"
 	echo "Unless you know what you're doing, you should stick with the default parameters provided by the script."
 	echo "Note that whatever you choose, all the choices presented in the script are safe. (Unlike OpenVPN's defaults)"
-	echo "See https://github.com/angristan/openvpn-install#security-and-encryption to learn more."
+	echo "See https://github.com/tuckyapps/openvpn-install#security-and-encryption to learn more."
 	echo ""
 	until [[ $CUSTOMIZE_ENC =~ (y|n) ]]; do
 		read -rp "Customize encryption settings? [y/n]: " -e -i n CUSTOMIZE_ENC
@@ -970,7 +969,7 @@ function newClient () {
 	echo "   2) Use a password for the client"
 
 	until [[ "$PASS" =~ ^[1-2]$ ]]; do
-		read -rp "Select an option [1-2]: " -e -i 1 PASS
+		read -rp "Select an option [1-2]: " -e -i 2 PASS
 	done
 
 	cd /etc/openvpn/easy-rsa/ || return
@@ -1185,7 +1184,7 @@ function removeOpenVPN () {
 function manageMenu () {
 	clear
 	echo "Welcome to OpenVPN-install!"
-	echo "The git repository is available at: https://github.com/angristan/openvpn-install"
+	echo "The git repository is available at: https://github.com/tuckyapps/openvpn-install"
 	echo ""
 	echo "It looks like OpenVPN is already installed."
 	echo ""


### PR DESCRIPTION
Adds option to establish connection with openvpn server through IPv6. This way, if your ISP is already giving you an IPv6 address, you will still be able to connect to your server.
The IPv6 address is added on client's configuration file, below the IPv4 remote instruction. This way, a user will always try to connect to the IPv4 one, and only if it has no luck, it will then try to connect using IPv6.

Note: When using udp, client will need to wait until keepalive time elapses before it tries to connect through IPv6. If you would like this switch to be fast, I suggest you use TCP protocol instead.