### PR TITLE
Added DHCP option

### DIFF
--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -921,6 +921,7 @@ verify-x509-name $SERVER_NAME name
 auth $HMAC_ALG
 auth-nocache
 cipher $CIPHER
+dhcp-option DNS 192.168.1.1
 tls-client
 tls-version-min 1.2
 tls-cipher $CC_CIPHER


### PR DESCRIPTION
Server: Digitalocean VPS Centos 7
Client: Debian 9

I have applied same instruction but it's didn't work. I have tried connect to google, it doesn't work. thereafter it wasn't connecting OpenDns but it resuming ssh connection. 

I searched internet and i found a answer. [Link adress](https://serverfault.com/questions/318563/how-to-push-my-own-dns-server-to-openvpn) it's say: 
```
script-security 2                                                                                                       
dhcp-option DNS 192.168.1.1                                                                                           
dhcp-option DOMAIN example.lan                                                                                   

# Only on ubuntu client, you also need following directives:                                                              
up /etc/openvpn/update-resolv-conf                                                                                      
down /etc/openvpn/update-resolv-conf 
```
but ''script-security'' is turned low status secuity and it's allow access some file.  I removed this lines:

```
script-security 2             
dhcp-option DOMAIN example.lan                                                                                   

# Only on ubuntu client, you also need following directives:                                                              
up /etc/openvpn/update-resolv-conf                                                                                      
down /etc/openvpn/update-resolv-conf 
```
Now it may use own router dns register. I have try your script on centos. It works normally but it's didn't work on debian 9.