### PR TITLE
Headless installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ If you have any question, head to the [FAQ](#faq) first.
 
 ### Headless install
 
-It's also possible to run the script headless.
+It's also possible to run the script headless, e.g. without waiting for user input, in an automated manner.
 
 Example usage:
 ```bash
@@ -51,10 +51,12 @@ export PROTOCOL_CHOICE=1
 export DNS=1
 export COMPRESSION_ENABLED=n
 export CUSTOMIZE_ENC=n
-export CLIENT=clientName
+export CLIENT=clientname
 export PASS=1
 ./openvpn-install.sh
 ```
+
+If the server is behind NAT, you can specify its endpoint with the `PUBLICIP` variable. It the endpoint is the public IP address which it is behind, you can use `export PUBLICIP=$(curl ifconfig.co)`.
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,25 @@ In your home directory, you will have `.ovpn` files. These are the client config
 
 If you have any question, head to the [FAQ](#faq) first.
 
+### Headless install
+
+It's also possible to run the script headless.
+
+Example usage:
+```bash
+export APPROVE_INSTALL=y
+export APPROVE_IP=y
+export IPV6_SUPPORT=n
+export PORT_CHOICE=1
+export PROTOCOL_CHOICE=1
+export DNS=1
+export COMPRESSION_ENABLED=n
+export CUSTOMIZE_ENC=n
+export CLIENT=clientName
+export PASS=1
+./openvpn-install.sh
+```
+
 ## Features
 
 - Installs and configures a ready-to-use OpenVPN server

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -197,7 +197,10 @@ function installQuestions () {
 
 	# Detect public IPv4 address and pre-fill for the user
 	IP=$(ip addr | grep 'inet' | grep -v inet6 | grep -vE '127\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' | grep -oE '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' | head -1)
-	read -rp "IP address: " -e -i "$IP" IP
+	APPROVE_IP=${APPROVE_IP:-n}
+	if [[ $APPROVE_IP =~ n ]]; then
+		read -rp "IP address: " -e -i "$IP" IP
+	fi
 	# If $IP is a private IP address, the server must be behind NAT
 	if echo "$IP" | grep -qE '^(10\.|172\.1[6789]\.|172\.2[0-9]\.|172\.3[01]\.|192\.168)'; then
 		echo ""
@@ -546,7 +549,10 @@ function installQuestions () {
 	echo ""
 	echo "Okay, that was all I needed. We are ready to setup your OpenVPN server now."
 	echo "You will be able to generate a client at the end of the installation."
-	read -n1 -r -p "Press any key to continue..."
+	APPROVE_INSTALL=${APPROVE_INSTALL:-n}
+	if [[ $APPROVE_INSTALL =~ n ]]; then
+		read -n1 -r -p "Press any key to continue..."
+	fi
 }
 
 function installOpenVPN () {


### PR DESCRIPTION
I've made some small changes to be able to support automatic installation (#261)
It does not support adding a password protected client, or installation behind a NAT, but it's a start.

For installation behind a NAT, the IP detection like could be changed to something like:
`IP=$(wget -q -O - https://api.ipify.org)`

Auto installation command:
```
export APPROVE_INSTALL=y
export APPROVE_IP=y
export IPV6_SUPPORT=n
export PORT_CHOICE=2
export PORT=11194
export PROTOCOL_CHOICE=1
export DNS=9
export COMPRESSION_ENABLED=n
export CUSTOMIZE_ENC=n
export CLIENT=clientName
export PASS=1
./openvpn-install.sh
```