### PR TITLE
Test for fedora earlier

### DIFF
--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -50,6 +50,8 @@ function checkOS () {
 				fi
 			fi
 		fi
+	elif [[ -e /etc/fedora-release ]]; then
+		OS=fedora
 	elif [[ -e /etc/system-release ]]; then
 		source /etc/os-release
 		if [[ "$ID" = "centos" ]]; then
@@ -72,8 +74,6 @@ function checkOS () {
 				exit 1
 			fi
 		fi
-	elif [[ -e /etc/fedora-release ]]; then
-		OS=fedora
 	elif [[ -e /etc/arch-release ]]; then
 		OS=arch
 	else


### PR DESCRIPTION
As reported in Bug #495 , fedora 30+ includes both /etc/os-release and  /etc/fedora-release. Current order tests os-release first, and does not correctly identify fedora 30+ installations.

This change moves the check for /etc/fedora-release prior to those for /etc/os-release.
