### PR TITLE
New feature: Split-tunnel configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ If you want to customise your installation, you can export them or specify them 
 - `CUSTOMIZE_ENC=n`
 - `CLIENT=clientname`
 - `PASS=1`
+- `TUNNEL_CIDR_BLOCKS="10.0.1.0/24 10.0.2.0/16"`
 
 If the server is behind NAT, you can specify its endpoint with the `ENDPOINT` variable. If the endpoint is the public IP address which it is behind, you can use `ENDPOINT=$(curl -4 ifconfig.co)` (the script will default to this). The endpoint can be an IPv4 or a domain.
 
@@ -83,6 +84,23 @@ export PASS="1"
 ./openvpn-install.sh
 ```
 
+### Split-tunnel usage
+If you only want to tunnel specific subnets through the VPN-tunnel, you can enable Split-tunnel configuration by passing the TUNNEL_CIDR_BLOCKS environment variable. For example, if you want to tunnel just the subnets 10.0.1.0 with netmask 255.255.255.0 and 10.0.2.0 with netmask 255.255.255.0, you specify 10.0.1.0/24 and 10.0.2.0/24:
+
+On the command line:
+```bash
+TUNNEL_CIDR_BLOCKS=(10.0.1.0/24 10.0.2.0/24) ./openvpn-install.sh
+```
+On in a script:
+```bash
+#!/bin/bash
+export TUNNEL_CIDR_BLOCKS="10.0.1.0/24 10.0.2.0/24"
+./openvpn-install.sh
+```
+_Notes:_
+- _Currently only 8-, 16-, 24- and 32-bits subnets are supported!_
+- _/bin/sh doesn't support array's, so bash is required._
+
 ## Features
 
 - Installs and configures a ready-to-use OpenVPN server
@@ -99,6 +117,7 @@ export PASS="1"
 - Block DNS leaks on Windows 10
 - Randomised server certificate name
 - Choice to protect clients with a password (private key encryption)
+- Split-tunnel configuration (experimental)
 - Many other little things!
 
 ## Compatibility

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -789,8 +789,8 @@ ifconfig-pool-persist ipp.txt" >> /etc/openvpn/server.conf
 	esac
 
 	# Allow split-tunnel via custom CIDR blocks (ie. 192.168.0.0/24)
-	if [ ${#PUSH_CIDR_BLOCKS[@]} -gt 0 ]; then
-		for cidr in ${PUSH_CIDR_BLOCKS[@]}; do
+	if [ ${#TUNNEL_CIDR_BLOCKS[@]} -gt 0 ]; then
+		for cidr in ${TUNNEL_CIDR_BLOCKS[@]}; do
 			echo "Adding $cidr to routed subnets...";
 			ROUTE_IP=$(echo $cidr | cut -d"/" -f1)
 			ROUTE_BITS=$(echo $cidr | cut -d"/" -f2)


### PR DESCRIPTION
I needed my tunnel to be split-tunnel, allowing me to browse the internet normally and only route specific subnets through the tunnel, so I've created a little routine to accommodate that:

See my changes in `openvpn-install.sh` at line 790 below. If TUNNEL_CIDR_BLOCKS is specified, the config will not push redirect-gateway def1 bypass-dhcp, but only route the specified subnet(s).

```bash
# Allow split-tunnel via custom CIDR blocks (ie. 192.168.0.0/24)
if [ ${#PUSH_CIDR_BLOCKS[@]} -gt 0 ]; then
	for cidr in ${PUSH_CIDR_BLOCKS[@]}; do
		echo "Adding $cidr to routed subnets...";
		ROUTE_IP=$(echo $cidr | cut -d"/" -f1)
		ROUTE_BITS=$(echo $cidr | cut -d"/" -f2)
		case $ROUTE_BITS in 
			8)  ROUTE_MASK="255.0.0.0" ;;
			16) ROUTE_MASK="255.255.0.0" ;;
			24) ROUTE_MASK="255.255.255.0" ;;
			32) ROUTE_MASK="255.255.255.255" ;;
		esac
		echo "push \"route ${ROUTE_IP} ${ROUTE_MASK}\"" >> /etc/openvpn/server.conf
	done
else
	echo 'push "redirect-gateway def1 bypass-dhcp"' >> /etc/openvpn/server.conf
fi
```

Hope you like it. Let me know if you want me to add a GUI for it and/or allow more subnet bit-lengths.