### PR TITLE
Install semanage command on CentOS

### DIFF
--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -624,7 +624,7 @@ function installOpenVPN () {
 		apt-get install -y openvpn iptables openssl wget ca-certificates curl
 	elif [[ "$OS" = 'centos' ]]; then
 		yum install -y epel-release
-		yum install -y openvpn iptables openssl wget ca-certificates curl tar
+		yum install -y openvpn iptables openssl wget ca-certificates curl tar 'policycoreutils-python*'
 	elif [[ "$OS" = 'amzn' ]]; then
 		amazon-linux-extras install -y epel
 		yum install -y openvpn iptables openssl wget ca-certificates curl


### PR DESCRIPTION
CentOS has selinux enabled by default but it hasn't the `semanage` command required to run OpenVPN on another port.

`policycoreutils-python*` match `policycoreutils-python` in CentOS 7 and `policycoreutils-python-utils` in Centos 8.

Fix #553.