### PR TITLE
Get public interface from IPv6

### DIFF
--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -606,6 +606,9 @@ function installOpenVPN () {
 
 	# Get the "public" interface from the default route
 	NIC=$(ip -4 route ls | grep default | grep -Po '(?<=dev )(\S+)' | head -1)
+	if [[ -z "$NIC" ]] && [[ "$IPV6_SUPPORT" = 'y' ]]; then
+		NIC=$(ip -6 route show default | sed -ne 's/^default .* dev \([^ ]*\) .*$/\1/p')
+	fi
 
 	if [[ "$OS" =~ (debian|ubuntu) ]]; then
 		apt-get update


### PR DESCRIPTION
In a IPv6 only environment, the variable $NIC would be empty and iptables in add-openvpn-rules.sh will fail by missing argument.