### PR TITLE
Add explicit-exit-notify for UDP

### DIFF
--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -961,6 +961,7 @@ WantedBy=multi-user.target" > /etc/systemd/system/iptables-openvpn.service
 	echo "client" > /etc/openvpn/client-template.txt
 	if [[ "$PROTOCOL" = 'udp' ]]; then
 		echo "proto udp" >> /etc/openvpn/client-template.txt
+		echo "explicit-exit-notify" >> /etc/openvpn/client-template.txt
 	elif [[ "$PROTOCOL" = 'tcp' ]]; then
 		echo "proto tcp-client" >> /etc/openvpn/client-template.txt
 	fi


### PR DESCRIPTION
For faster reconnects with UDP is better to send the the explicit-exit-notify to server. With this the server can directly see, that the client will exit.