### PR TITLE
Fix error message mkdir /etc/iptables

### DIFF
--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -897,7 +897,7 @@ verb 3" >> /etc/openvpn/server.conf
 	fi
 
 	# Add iptables rules in two scripts
-	mkdir /etc/iptables
+	mkdir -p /etc/iptables
 
 	# Script to add rules
 	echo "#!/bin/sh


### PR DESCRIPTION
Fix this error message:
mkdir: cannot create directory ‘/etc/iptables’: File exists