### PR TITLE
Simplify detection of public IP4, add IPv6

### DIFF
--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -207,6 +207,10 @@ function installQuestions () {
 
 	# Detect public IPv4 address and pre-fill for the user
 	IP=$(ip -4 addr | sed -ne 's|^.* inet \([^/]*\)/.* scope global.*$|\1|p' | head -1)
+	if [[ -z "$IP" ]]; then
+		# Detect public IPv6 address
+		IP=$(ip -6 addr | sed -ne 's|^.* inet6 \([^/]*\)/.* scope global.*$|\1|p' | head -1)
+	fi
 	APPROVE_IP=${APPROVE_IP:-n}
 	if [[ $APPROVE_IP =~ n ]]; then
 		read -rp "IP address: " -e -i "$IP" IP

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -206,7 +206,7 @@ function installQuestions () {
 	echo "Unless your server is behind NAT, it should be your public IPv4 address."
 
 	# Detect public IPv4 address and pre-fill for the user
-	IP=$(ip addr | grep 'inet' | grep -v inet6 | grep -vE '127\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' | grep -oE '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' | head -1)
+	IP=$(ip -4 addr | sed -ne 's|^.* inet \([^/]*\)/.* scope global.*$|\1|p' | head -1)
 	APPROVE_IP=${APPROVE_IP:-n}
 	if [[ $APPROVE_IP =~ n ]]; then
 		read -rp "IP address: " -e -i "$IP" IP


### PR DESCRIPTION
Detect public IP4 more simple.
"ip addr | ... | grep -v inet6" replaced with "ip -4 addr".
"grep -vE '127\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}'" repleced with search for "scope global".
"grep 'inet' | ... | grep -oE '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}'" replaced with search for first word after "inet".
All grep in one "sed".

Add the same for IPv6, if IPv4 not found found.