### PR TITLE
Idempotent in headless mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ Other variables can be set depending on your choice (encryption, compression). Y
 
 Password-protected clients are not supported by the headless installation method since user input is expected by Easy-RSA.
 
+The headless install is more-or-less idempotent, in that it has been made safe to run multiple times with the same parameters, e.g. by a state provisioner like Terraform/Salt/Chef/Puppet. It will only install and regenerate the Easy-RSA PKI if it doesn't already exist, and it will only install OpenVPN and other upstream dependencies if OpenVPN isn't already installed. It will recreate all local config and re-generate the client file on each headless run.
+
 ### Headless User Addition
 
 It's also possible to automate the addition of a new user. Here, the key is to provide the (string) value of the `MENU_OPTION` variable along with the remaining mandatory variables before invoking the script.

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Other variables can be set depending on your choice (encryption, compression). Y
 
 Password-protected clients are not supported by the headless installation method since user input is expected by Easy-RSA.
 
-The headless install is more-or-less idempotent, in that it has been made safe to run multiple times with the same parameters, e.g. by a state provisioner like Terraform/Salt/Chef/Puppet. It will only install and regenerate the Easy-RSA PKI if it doesn't already exist, and it will only install OpenVPN and other upstream dependencies if OpenVPN isn't already installed. It will recreate all local config and re-generate the client file on each headless run.
+The headless install is more-or-less idempotent, in that it has been made safe to run multiple times with the same parameters, e.g. by a state provisioner like Ansible/Terraform/Salt/Chef/Puppet. It will only install and regenerate the Easy-RSA PKI if it doesn't already exist, and it will only install OpenVPN and other upstream dependencies if OpenVPN isn't already installed. It will recreate all local config and re-generate the client file on each headless run.
 
 ### Headless User Addition
 

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -662,6 +662,9 @@ function installOpenVPN () {
 			# Install required dependencies and upgrade the system
 			pacman --needed --noconfirm -Syu openvpn iptables openssl wget ca-certificates curl
 		fi
+		if [[ -d /etc/openvpn/easy-rsa/ ]]; then
+			rm -rf /etc/openvpn/easy-rsa/
+		fi
 	fi
 
 	# Find out if the machine uses nogroup or nobody for the permissionless group
@@ -678,7 +681,7 @@ function installOpenVPN () {
 
 	# Install the latest version of easy-rsa from source, if not already
 	# installed.
-	if [[ ! -d /etc/openvpn/easy-rsa-auto/ ]]; then
+	if [[ ! -d /etc/openvpn/easy-rsa/ ]]; then
 		local version="3.0.6"
 		wget -O ~/EasyRSA-unix-v${version}.tgz https://github.com/OpenVPN/easy-rsa/releases/download/v${version}/EasyRSA-unix-v${version}.tgz
 		tar xzf ~/EasyRSA-unix-v${version}.tgz -C ~/

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -662,6 +662,7 @@ function installOpenVPN () {
 			# Install required dependencies and upgrade the system
 			pacman --needed --noconfirm -Syu openvpn iptables openssl wget ca-certificates curl
 		fi
+		# An old version of easy-rsa was available by default in some openvpn packages
 		if [[ -d /etc/openvpn/easy-rsa/ ]]; then
 			rm -rf /etc/openvpn/easy-rsa/
 		fi
@@ -672,11 +673,6 @@ function installOpenVPN () {
 		NOGROUP=nogroup
 	else
 		NOGROUP=nobody
-	fi
-
-	# An old version of easy-rsa was available by default in some openvpn packages
-	if [[ -d /etc/openvpn/easy-rsa/ ]]; then
-		rm -rf /etc/openvpn/easy-rsa/
 	fi
 
 	# Install the latest version of easy-rsa from source, if not already

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -601,11 +601,11 @@ function installOpenVPN () {
 
 		# Behind NAT, we'll default to the publicly reachable IPv4/IPv6.
 		if [[ $IPV6_SUPPORT == "y" ]]; then
-			PUBLIC_IPV4=$(curl https://ifconfig.co)
+			PUBLIC_IP=$(curl https://ifconfig.co)
 		else
-			PUBLIC_IPV4=$(curl -4 https://ifconfig.co)
+			PUBLIC_IP=$(curl -4 https://ifconfig.co)
 		fi
-		ENDPOINT=${ENDPOINT:-$PUBLIC_IPV4}
+		ENDPOINT=${ENDPOINT:-$PUBLIC_IP}
 	fi
 
 	# Run setup questions first, and set other variales if auto-install

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -601,9 +601,9 @@ function installOpenVPN () {
 
 		# Behind NAT, we'll default to the publicly reachable IPv4/IPv6.
 		if [[ $IPV6_SUPPORT == "y" ]]; then
-			PUBLIC_IPV4=$(curl ifconfig.co)
+			PUBLIC_IPV4=$(curl https://ifconfig.co)
 		else
-			PUBLIC_IPV4=$(curl -4 ifconfig.co)
+			PUBLIC_IPV4=$(curl -4 https://ifconfig.co)
 		fi
 		ENDPOINT=${ENDPOINT:-$PUBLIC_IPV4}
 	fi


### PR DESCRIPTION
This changeset adjusts the script so that you can run it multiple times with the same input and not have any unexpected changes. This makes it appropriate for "enforcing state", as required by automated provisioners like Puppet, Salt, Chef, or Ansible.

 - Unbound, OpenVPN, easy-rsa, and other dependencies are only installed from upstream if they are not already present. This prevents multiple runs of the script from causing unexpected version upgrades.
 - The easy-rsa CA is only initialized once
 - SERVER_CN and SERVER_NAME are randomly generated once and saved for future reference
 - File append ('>>') is only done strictly after a file is created with '>' (e.g. /etc/sysctl.d/20-openvpn.conf)
 - Clients are only added to easy-rsa once
 - If AUTO_INSTALL == y, then the script operates in install mode and doesn't enter manageMenu

Also, IPv4-only mode has been fixed with a call to curl -4 ifconfig.co.

Fixes: #545 