### PR TITLE
Add support for client-configuration-dir

### DIFF
--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -854,7 +854,7 @@ status /var/log/openvpn/status.log
 verb 3" >> /etc/openvpn/server.conf
 
 	# Create ccd dir
-	mkdir /etc/openvpn/ccd
+	mkdir -p /etc/openvpn/ccd
 	# Create log dir
 	mkdir -p /var/log/openvpn
 

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -849,7 +849,7 @@ ncp-ciphers $CIPHER
 tls-server
 tls-version-min 1.2
 tls-cipher $CC_CIPHER
-client-config-dir ccd
+client-config-dir /etc/openvpn/ccd
 status /var/log/openvpn/status.log
 verb 3" >> /etc/openvpn/server.conf
 

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -849,9 +849,12 @@ ncp-ciphers $CIPHER
 tls-server
 tls-version-min 1.2
 tls-cipher $CC_CIPHER
+client-config-dir ccd
 status /var/log/openvpn/status.log
 verb 3" >> /etc/openvpn/server.conf
 
+	# Create ccd dir
+	mkdir /etc/openvpn/ccd
 	# Create log dir
 	mkdir -p /var/log/openvpn
 

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -853,7 +853,7 @@ client-config-dir /etc/openvpn/ccd
 status /var/log/openvpn/status.log
 verb 3" >> /etc/openvpn/server.conf
 
-	# Create ccd dir
+	# Create client-config-dir dir
 	mkdir -p /etc/openvpn/ccd
 	# Create log dir
 	mkdir -p /var/log/openvpn


### PR DESCRIPTION
I didn't add the code to create `/etc/openvpn/ccd/$CLIENT` files because it's cleaner to have there only the clients that are using the client specific options.

Fix #606