### PR TITLE
Update distro compatibility list

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ The script supports these OS and architectures:
 | CentOS 8        | ❌   | ✅    | ❌    | ✅    |
 | Debian >= 9     | ✅   | ✅    | ✅    | ✅    |
 | Fedora >= 27    | ❔   | ✅    | ❔    | ❔    |
-| Ubuntu 16.04    | ✅   | ✅    | ❔    | ❔    |
+| Ubuntu 16.04    | ✅   | ✅    | ❌    | ❌    |
 | Ubuntu >= 18.04 | ✅   | ✅    | ✅    | ✅    |
 
 To be noted:

--- a/README.md
+++ b/README.md
@@ -119,7 +119,6 @@ The script supports these OS and architectures:
 | Arch Linux      | ❔   | ✅    | ❔    | ✅    |
 | CentOS 7        | ✅   | ✅    | ✅    | ✅    |
 | CentOS 8        | ❌   | ✅    | ❌    | ✅    |
-| Debian 8        | ✅   | ✅    | ✅    | ✅    |
 | Debian >= 9     | ✅   | ✅    | ✅    | ✅    |
 | Fedora >= 27    | ❔   | ✅    | ❔    | ❔    |
 | Ubuntu 16.04    | ✅   | ✅    | ❔    | ❔    |

--- a/README.md
+++ b/README.md
@@ -117,13 +117,13 @@ The script supports these OS and architectures:
 | --------------- | ---- | ----- | ----- | ----- |
 | Amazon Linux 2  | ❔   | ✅    | ❔    | ❔    |
 | Arch Linux      | ❔   | ✅    | ❔    | ✅    |
-| CentOS 7        | ❔   | ✅    | ❌    | ✅    |
-| CentOS 8        | ❌   | ✅    | ❔    | ❔    |
-| Debian 8        | ✅   | ✅    | ❌    | ❌    |
-| Debian >= 9     | ❌   | ✅    | ✅    | ✅    |
+| CentOS 7        | ✅   | ✅    | ✅    | ✅    |
+| CentOS 8        | ❌   | ✅    | ❌    | ✅    |
+| Debian 8        | ✅   | ✅    | ✅    | ✅    |
+| Debian >= 9     | ✅   | ✅    | ✅    | ✅    |
 | Fedora >= 27    | ❔   | ✅    | ❔    | ❔    |
-| Ubuntu 16.04    | ✅   | ✅    | ❌    | ❌    |
-| Ubuntu >= 18.04 | ❌   | ✅    | ✅    | ✅    |
+| Ubuntu 16.04    | ✅   | ✅    | ❔    | ❔    |
+| Ubuntu >= 18.04 | ✅   | ✅    | ✅    | ✅    |
 
 To be noted:
 

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -22,10 +22,10 @@ function checkOS() {
 		source /etc/os-release
 
 		if [[ $ID == "debian" || $ID == "raspbian" ]]; then
-			if [[ $VERSION_ID -lt 8 ]]; then
+			if [[ $VERSION_ID -lt 9 ]]; then
 				echo "⚠️ Your version of Debian is not supported."
 				echo ""
-				echo "However, if you're using Debian >= 8 or unstable/testing then you can continue, at your own risk."
+				echo "However, if you're using Debian >= 9 or unstable/testing then you can continue, at your own risk."
 				echo ""
 				until [[ $CONTINUE =~ (y|n) ]]; do
 					read -rp "Continue? [y/n]: " -e CONTINUE
@@ -653,11 +653,6 @@ function installOpenVPN() {
 			apt-get update
 			apt-get -y install ca-certificates gnupg
 			# We add the OpenVPN repo to get the latest version.
-			if [[ $VERSION_ID == "8" ]]; then
-				echo "deb http://build.openvpn.net/debian/openvpn/stable jessie main" >/etc/apt/sources.list.d/openvpn.list
-				wget -O - https://swupdate.openvpn.net/repos/repo-public.gpg | apt-key add -
-				apt-get update
-			fi
 			if [[ $VERSION_ID == "16.04" ]]; then
 				echo "deb http://build.openvpn.net/debian/openvpn/stable xenial main" >/etc/apt/sources.list.d/openvpn.list
 				wget -O - https://swupdate.openvpn.net/repos/repo-public.gpg | apt-key add -

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -22,10 +22,10 @@ function checkOS() {
 		source /etc/os-release
 
 		if [[ $ID == "debian" || $ID == "raspbian" ]]; then
-			if [[ $VERSION_ID -lt 8 ]]; then
+			if [[ $VERSION_ID -lt 9 ]]; then
 				echo "⚠️ Your version of Debian is not supported."
 				echo ""
-				echo "However, if you're using Debian >= 8 or unstable/testing then you can continue, at your own risk."
+				echo "However, if you're using Debian >= 9 or unstable/testing then you can continue, at your own risk."
 				echo ""
 				until [[ $CONTINUE =~ (y|n) ]]; do
 					read -rp "Continue? [y/n]: " -e CONTINUE


### PR DESCRIPTION
- Centos 7 i386 is supported. armhf images and epel repository are available [link](https://wiki.centos.org/SpecialInterestGroup/AltArch/armhfp#How_Can_I_Enable_EPEL_7_on_armhfp_.3F)
- Centos 8 isn't available on armhf but has images for arm64. Epel for armhf can be used on arm64 [link](http://isoredirect.centos.org/altarch/)
- Debian 8 for armhf and arm64 is available [link](https://packages.debian.org/jessie/openvpn)
- Debian 9 for i386 is available
- There are some images for Ubuntu 16.04 armhf and arm64 but compatibility is ? [link](http://old-releases.ubuntu.com/releases/xenial/)
- Ubuntu 18.04 supports i386, armhf and arm64 because of Ubuntu Mate [link](https://ubuntu-mate.org/download/)
