### PR TITLE
Add auth-gen-token server option

### DIFF
--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -890,6 +890,7 @@ ncp-ciphers $CIPHER
 tls-server
 tls-version-min 1.2
 tls-cipher $CC_CIPHER
+auth-gen-token
 client-config-dir /etc/openvpn/ccd
 status /var/log/openvpn/status.log
 verb 3" >>/etc/openvpn/server.conf


### PR DESCRIPTION
Every hour a renegotiation can cause custom configurations to fail because of a necessary input of the credentials. `auth-gen-token` option prevents this.

From the OpenVPN manual:
> The purpose of this is to enable two factor authentication methods, such as HOTP or TOTP, to be used without needing to retrieve a new OTP code each time the connection is renegotiated. Another use case is to cache authentication data on the client without needing to have the users password cached in memory during the life time of the session.


Needs testing, see [BUG](https://community.openvpn.net/openvpn/ticket/840)