### PR TITLE
Update openvpn-install.sh

### DIFF
--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -618,7 +618,7 @@ function installOpenVPN() {
 		if [[ $IPV6_SUPPORT == "y" ]]; then
 			PUBLIC_IP=$(curl https://ifconfig.co)
 		else
-			PUBLIC_IP=$(curl -4 https://ifconfig.co)
+			PUBLIC_IP=$(curl -4 https://ip.me)
 		fi
 		ENDPOINT=${ENDPOINT:-$PUBLIC_IP}
 	fi


### PR DESCRIPTION
Updated openvpn-install.sh to use ip.me since ifconfig.co is not working

Curling Ifconfig.co returns a Heroku application error response instead of the correct IP.
![image](https://user-images.githubusercontent.com/17788274/82913066-d72a9380-9f3b-11ea-8cb2-1790077e19e4.png)

I updated the ipv4 section to use the tool https://ip.me, however do not have a replacement for the ipv6 portion. 