### PR TITLE
Fix README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ Most of OpenVPN's encryption-related stuff is managed by [Easy-RSA](https://gith
 
 By default, OpenVPN doesn't enable compression. This script provides support for LZ0 and LZ4 (v1/v2) algorithms, the latter being more efficient.
 
-However, it is discouraged to use compression since it since the [VORACLE attack](https://protonvpn.com/blog/voracle-attack/) makes use of it.
+However, it is discouraged to use compression since the [VORACLE attack](https://protonvpn.com/blog/voracle-attack/) makes use of it.
 
 ### TLS version
 

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -61,7 +61,7 @@ function checkOS() {
 			if [[ ! $VERSION_ID =~ (7|8) ]]; then
 				echo "⚠️ Your version of CentOS is not supported."
 				echo ""
-				echo "The script only support CentOS 7."
+				echo "The script only support CentOS 7 and CentOS 8."
 				echo ""
 				exit 1
 			fi


### PR DESCRIPTION
Fix a small typo on the README for the VORACLE Attack.

Also update the error message in case the CentOS version is not supported by the script.