### PR TITLE
Default DNS to AdGuard

### DIFF
--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -315,7 +315,7 @@ function installQuestions() {
 	echo "   12) NextDNS (Anycast: worldwide)"
 	echo "   13) Custom"
 	until [[ $DNS =~ ^[0-9]+$ ]] && [ "$DNS" -ge 1 ] && [ "$DNS" -le 13 ]; do
-		read -rp "DNS [1-12]: " -e -i 3 DNS
+		read -rp "DNS [1-12]: " -e -i 11 DNS
 		if [[ $DNS == 2 ]] && [[ -e /etc/unbound/unbound.conf ]]; then
 			echo ""
 			echo "Unbound is already installed."


### PR DESCRIPTION
Inspired by #595 ; open to discussion.

As specified in the [wireguard-install](https://github.com/angristan/wireguard-install/blob/master/wireguard-install.sh#L21) repository, we use AdGuard DNS by default. I believe we should use the same DNS provider to ensure privacy by default; and maintain a same path in between all repositories.