### PR TITLE
Fix GitHub Actions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,6 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+      with:
+        ref: master
+
     - name: shellcheck
       uses: ludeeus/action-shellcheck@0.4.1
       env:
@@ -21,7 +24,10 @@ jobs:
   shfmt:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
+      with:
+        ref: master
+
     - name: shfmt
       uses: bltavares/actions/shfmt@master
       env:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,9 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-      with:
-        ref: master
-
     - name: shellcheck
       uses: ludeeus/action-shellcheck@0.4.1
       env:
@@ -25,9 +22,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-      with:
-        ref: master
-
     - name: shfmt
       uses: bltavares/actions/shfmt@master
       env:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,7 +24,7 @@ jobs:
   shfmt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+    - uses: actions/checkout@v2
       with:
         ref: master
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,9 @@ jobs:
           - centos-7-x64
           - centos-8-x64
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v2
+      with:
+        ref: master
 
     - name: Setup doctl
       uses: digitalocean/action-doctl@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,8 +22,6 @@ jobs:
           - centos-8-x64
     steps:
     - uses: actions/checkout@v2
-      with:
-        ref: master
 
     - name: Setup doctl
       uses: digitalocean/action-doctl@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,7 @@ jobs:
 
     - name: Setup remote server (Debian/Ubuntu)
       if: steps.server_os.outputs.value == 'debian' || steps.server_os.outputs.value == 'ubuntu'
-      uses: appleboy/ssh-action@master
+      uses: appleboy/ssh-action@v0.1.2
       with:
         host: ${{ steps.server_ip.outputs.value }}
         username: root
@@ -62,7 +62,7 @@ jobs:
 
     - name: Setup remote server (Fedora)
       if: steps.server_os.outputs.value == 'fedora'
-      uses: appleboy/ssh-action@master
+      uses: appleboy/ssh-action@v0.1.2
       with:
         host: ${{ steps.server_ip.outputs.value }}
         username: root
@@ -71,7 +71,7 @@ jobs:
 
     - name: Setup remote server (CentOS)
       if: steps.server_os.outputs.value == 'centos'
-      uses: appleboy/ssh-action@master
+      uses: appleboy/ssh-action@v0.1.2
       with:
         host: ${{ steps.server_ip.outputs.value }}
         username: root
@@ -79,7 +79,7 @@ jobs:
         script: set -x && yum install -y git
 
     - name: Download repo and checkout current commit
-      uses: appleboy/ssh-action@master
+      uses: appleboy/ssh-action@v0.1.2
       with:
         host: ${{ steps.server_ip.outputs.value }}
         username: root
@@ -87,7 +87,7 @@ jobs:
         script: set -x && git clone https://github.com/angristan/openvpn-install.git && cd openvpn-install && git checkout ${{ github.event.pull_request.head.sha }}
 
     - name: Run openvpn-install.sh in headless mode
-      uses: appleboy/ssh-action@master
+      uses: appleboy/ssh-action@v0.1.2
       with:
         host: ${{ steps.server_ip.outputs.value }}
         username: root


### PR DESCRIPTION
- Pin GitHub Actions checkout version as using ['master' will not be the default branch](https://github.com/angristan/openvpn-install/actions/runs/182285350) anymore.

<img width="1422" alt="Screenshot 2020-07-25 at 15 31 15" src="https://user-images.githubusercontent.com/16455953/88458117-e2dafd80-ce8b-11ea-852f-e32d8bd6347f.png">

- Avoid breaking changes by pinning a released version of the Actions for ssh-action.
