### PR TITLE
Rebased: Making Client Revocation Headless and Documenting New Feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,18 @@ export PASS="1"
 ./openvpn-install.sh
 ```
 
+### Headless User Removal
+
+The removal of an existing user can also be fully automated. Again, the key is to provide the (string) value of the `MENU_OPTION` variable along with the remaining mandatory variables before invoking the script.
+
+The following Bash script removes the existing user `bar` from an OpenVPN configuration
+```bash
+#!/bin/bash
+export MENU_OPTION="2"
+export CLIENT="bar"
+./openvpn-install.sh
+```
+
 ## Features
 
 - Installs and configures a ready-to-use OpenVPN server

--- a/README.md
+++ b/README.md
@@ -70,6 +70,19 @@ Other variables can be set depending on your choice (encryption, compression). Y
 
 Password-protected clients are not supported by the headless installation method since user input is expected by Easy-RSA.
 
+### Headless User Removal
+
+The removal of an existing user can also be fully automated. Again, the key is to provide the (string) value of the `MENU_OPTION` variable along with the remaining mandatory variables before invoking the script.
+
+The following Bash script removes the existing user `bar` from an OpenVPN configuration
+```bash
+#!/bin/bash
+export MENU_OPTION="2"
+export CLIENT="bar"
+./openvpn-install.sh
+```
+
+
 ## Features
 
 - Installs and configures a ready-to-use OpenVPN server

--- a/README.md
+++ b/README.md
@@ -70,6 +70,20 @@ Other variables can be set depending on your choice (encryption, compression). Y
 
 Password-protected clients are not supported by the headless installation method since user input is expected by Easy-RSA.
 
+### Headless User Addition
+
+It's also possible to automate the addition of a new user. Here, the key is to provide the (string) value of the `MENU_OPTION` variable along with the remaining mandatory variables before invoking the script.
+
+The following Bash script adds a new user `foo` to an existing OpenVPN configuration
+```bash
+#!/bin/bash
+export MENU_OPTION="1"
+export CLIENT="foo"
+export PASS="1"
+./openvpn-install.sh
+```
+
+
 ## Features
 
 - Installs and configures a ready-to-use OpenVPN server

--- a/README.md
+++ b/README.md
@@ -6,6 +6,13 @@ This script will let you setup your own secure VPN server in just a few seconds.
 
 You can also check out [wireguard-install](https://github.com/angristan/wireguard-install), a simple installer for a simpler, safer, faster and more modern VPN protocol.
 
+
+##  One-Stop Solutions for the Public Cloud
+
+Solutions that provision a ready to use OpenVPN server based on `openvpn-install` in one go are available for
+ - AWS using Terraform at [`openvpn-terraform-install`](https://github.com/dumrauf/openvpn-terraform-install) and described in [Ready to Use OpenVPN Servers in AWS For Everyone](https://www.how-hard-can-it.be/openvpn-server-install-terraform-aws/)
+
+
 ## Usage
 
 First, get the script and make it executable :

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -1072,16 +1072,18 @@ function revokeClient () {
 		exit 1
 	fi
 
-	echo ""
-	echo "Select the existing client certificate you want to revoke"
-	tail -n +2 /etc/openvpn/easy-rsa/pki/index.txt | grep "^V" | cut -d '=' -f 2 | nl -s ') '
-	if [[ "$NUMBEROFCLIENTS" = '1' ]]; then
-		read -rp "Select one client [1]: " CLIENTNUMBER
-	else
-		read -rp "Select one client [1-$NUMBEROFCLIENTS]: " CLIENTNUMBER
-	fi
+	until [[ "$CLIENT" =~ ^[a-zA-Z0-9_]+$ ]]; do
+		echo ""
+		echo "Select the existing client certificate you want to revoke"
+		tail -n +2 /etc/openvpn/easy-rsa/pki/index.txt | grep "^V" | cut -d '=' -f 2 | nl -s ') '
+		if [[ "$NUMBEROFCLIENTS" = '1' ]]; then
+			read -rp "Select one client [1]: " CLIENTNUMBER
+		else
+			read -rp "Select one client [1-$NUMBEROFCLIENTS]: " CLIENTNUMBER
+		fi
 
-	CLIENT=$(tail -n +2 /etc/openvpn/easy-rsa/pki/index.txt | grep "^V" | cut -d '=' -f 2 | sed -n "$CLIENTNUMBER"p)
+		CLIENT=$(tail -n +2 /etc/openvpn/easy-rsa/pki/index.txt | grep "^V" | cut -d '=' -f 2 | sed -n "$CLIENTNUMBER"p)
+	done
 	cd /etc/openvpn/easy-rsa/
 	./easyrsa --batch revoke "$CLIENT"
 	EASYRSA_CRL_DAYS=3650 ./easyrsa gen-crl

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -1144,14 +1144,16 @@ function revokeClient() {
 	echo ""
 	echo "Select the existing client certificate you want to revoke"
 	tail -n +2 /etc/openvpn/easy-rsa/pki/index.txt | grep "^V" | cut -d '=' -f 2 | nl -s ') '
-	until [[ $CLIENTNUMBER -ge 1 && $CLIENTNUMBER -le $NUMBEROFCLIENTS ]]; do
-		if [[ $CLIENTNUMBER == '1' ]]; then
-			read -rp "Select one client [1]: " CLIENTNUMBER
-		else
-			read -rp "Select one client [1-$NUMBEROFCLIENTS]: " CLIENTNUMBER
-		fi
+	until [[ "$CLIENT" =~ ^[a-zA-Z0-9_]+$ ]]; do
+		until [[ $CLIENTNUMBER -ge 1 && $CLIENTNUMBER -le $NUMBEROFCLIENTS ]]; do
+			if [[ $CLIENTNUMBER == '1' ]]; then
+				read -rp "Select one client [1]: " CLIENTNUMBER
+			else
+				read -rp "Select one client [1-$NUMBEROFCLIENTS]: " CLIENTNUMBER
+			fi
+		done
+		CLIENT=$(tail -n +2 /etc/openvpn/easy-rsa/pki/index.txt | grep "^V" | cut -d '=' -f 2 | sed -n "$CLIENTNUMBER"p)
 	done
-	CLIENT=$(tail -n +2 /etc/openvpn/easy-rsa/pki/index.txt | grep "^V" | cut -d '=' -f 2 | sed -n "$CLIENTNUMBER"p)
 	cd /etc/openvpn/easy-rsa/ || return
 	./easyrsa --batch revoke "$CLIENT"
 	EASYRSA_CRL_DAYS=3650 ./easyrsa gen-crl

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -1144,7 +1144,7 @@ function revokeClient() {
 	echo ""
 	echo "Select the existing client certificate you want to revoke"
 	tail -n +2 /etc/openvpn/easy-rsa/pki/index.txt | grep "^V" | cut -d '=' -f 2 | nl -s ') '
-	until [[ "$CLIENT" =~ ^[a-zA-Z0-9_]+$ ]]; do
+	until [[ $CLIENT =~ ^[a-zA-Z0-9_]+$ ]]; do
 		until [[ $CLIENTNUMBER -ge 1 && $CLIENTNUMBER -le $NUMBEROFCLIENTS ]]; do
 			if [[ $CLIENTNUMBER == '1' ]]; then
 				read -rp "Select one client [1]: " CLIENTNUMBER


### PR DESCRIPTION
Hello, this PR adds headless client revocation. Closes #486 and closes #489 (old PR that I've taken code from).

I've taken dumrauf's work and made a rebase, so the PR is relevant once again and ready to be merged.

I don't know bash that much, just thought a little help won't hurt. Tell me if there's anything else I can do regarding this feature.