### PR TITLE
Remove key-direction from tls-crypt option

### DIFF
--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -861,7 +861,7 @@ push "redirect-gateway ipv6"' >>/etc/openvpn/server.conf
 
 	case $TLS_SIG in
 	1)
-		echo "tls-crypt tls-crypt.key 0" >>/etc/openvpn/server.conf
+		echo "tls-crypt tls-crypt.key" >>/etc/openvpn/server.conf
 		;;
 	2)
 		echo "tls-auth tls-auth.key 0" >>/etc/openvpn/server.conf


### PR DESCRIPTION
In contrast to --tls-auth, --tls-crypt does *not* require the user to set --key-direction. Thus syntax is `--tls-crypt keyfile`