### PR TITLE
Remove unnecessary cipher configuration on Fedora

### DIFF
--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -917,10 +917,6 @@ verb 3" >>/etc/openvpn/server.conf
 		sed -i 's|LimitNPROC|#LimitNPROC|' /etc/systemd/system/openvpn-server@.service
 		# Another workaround to keep using /etc/openvpn/
 		sed -i 's|/etc/openvpn/server|/etc/openvpn|' /etc/systemd/system/openvpn-server@.service
-		# On fedora, the service hardcodes the ciphers. We want to manage the cipher ourselves, so we remove it from the service
-		if [[ $OS == "fedora" ]]; then
-			sed -i 's|--cipher AES-256-GCM --ncp-ciphers AES-256-GCM:AES-128-GCM:AES-256-CBC:AES-128-CBC:BF-CBC||' /etc/systemd/system/openvpn-server@.service
-		fi
 
 		systemctl daemon-reload
 		systemctl enable openvpn-server@server


### PR DESCRIPTION
Based on the fact that OpenVPN 2.5 removes the `BF-CBC` cipher from the default configuration, I expected Fedora to update its ciphers line in the RC3 of the package too which they didn't.

Upon investigation on why Fedora hard-codes the ciphers in the service file, I found out that
> If an already configured OpenVPN v2.4 based server configuration deploys `--cipher` and/or `--ncp-ciphers`, the options in the configuration file will override command line options set before `--config`. This should not break any existing configuration. 

This means that the values of `cipher` and `ncp-ciphers` we already specify in our server config will overwrite the command line options from the service file, making the `sed` command unnecessary.

Source: https://fedoraproject.org/wiki/Changes/New_default_cipher_in_OpenVPN