### PR TITLE
Compatibility with RHEL+EPEL

### DIFF
--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -52,7 +52,7 @@ function checkOS() {
 		fi
 	elif [[ -e /etc/system-release ]]; then
 		source /etc/os-release
-		if [[ $ID == "fedora" ]]; then
+		if [[ $ID == "fedora" || $ID_LIKE == "fedora" ]]; then
 			OS="fedora"
 		fi
 		if [[ $ID == "centos" ]]; then


### PR DESCRIPTION
Fixes that on RHEL the installer simply falls-through this lines:

https://github.com/angristan/openvpn-install/blob/ea236de3e32d2404632f6ccf63b1b4b9ee36f647/openvpn-install.sh#L53-L77

