### PR TITLE
Revoke client fixed

### DIFF
--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -1185,6 +1185,8 @@ function revokeClient() {
 	find /home/ -maxdepth 2 -name "$CLIENT.ovpn" -delete
 	rm -f "/root/$CLIENT.ovpn"
 	sed -i "/^$CLIENT,.*/d" /etc/openvpn/ipp.txt
+	cp /etc/openvpn/easy-rsa/pki/index.txt{,.bk}
+	sed -i -e '/^[R]/d' /etc/openvpn/easy-rsa/pki/index.txt
 
 	echo ""
 	echo "Certificate for client $CLIENT revoked."


### PR DESCRIPTION
Delete old client references in easy-rsa index.txt, it's useful if you delete and recreate a user with the same name