### PR TITLE
Add support for AlmaLinux 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ![Lint](https://github.com/angristan/openvpn-install/workflows/Lint/badge.svg)
 ![visitors](https://visitor-badge.glitch.me/badge?page_id=angristan.openvpn-install)
 
-OpenVPN installer for Debian, Ubuntu, Fedora, CentOS, Arch Linux, Oracle Linux and Rocky Linux.
+OpenVPN installer for Debian, Ubuntu, Fedora, CentOS, Arch Linux, Oracle Linux, Rocky Linux and AlmaLinux.
 
 This script will let you setup your own secure VPN server in just a few seconds.
 
@@ -127,6 +127,7 @@ The script supports these OS and architectures:
 | Ubuntu >= 18.04 | ✅   | ✅    | ✅    | ✅    |
 | Oracle Linux 8  | ❌   | ✅    | ❌    | ❔    |
 | Rocky Linux 8   |  ❔  | ✅    |  ❔   | ❔    |
+| AlmaLinux 8     | ❌   | ✅    | ❌    | ❔    |
 
 To be noted:
 

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # shellcheck disable=SC1091,SC2164,SC2034,SC1072,SC1073,SC1009
 
-# Secure OpenVPN server installer for Debian, Ubuntu, CentOS, Amazon Linux 2, Fedora, Oracle Linux 8, Arch Linux and Rocky Linux.
+# Secure OpenVPN server installer for Debian, Ubuntu, CentOS, Amazon Linux 2, Fedora, Oracle Linux 8, Arch Linux, Rocky Linux and AlmaLinux.
 # https://github.com/angristan/openvpn-install
 
 function isRoot() {
@@ -55,7 +55,7 @@ function checkOS() {
 		if [[ $ID == "fedora" || $ID_LIKE == "fedora" ]]; then
 			OS="fedora"
 		fi
-		if [[ $ID == "centos" || $ID == "rocky" ]]; then
+		if [[ $ID == "centos" || $ID == "rocky" || $ID == "almalinux" ]]; then
 			OS="centos"
 			if [[ ! $VERSION_ID =~ (7|8) ]]; then
 				echo "⚠️ Your version of CentOS is not supported."


### PR DESCRIPTION
AlmaLinux OS is 1:1 binary compatible with RHEL and pre-Stream CentOS.

Since Rocky Linux support is added, Alma should be added to to the checkOS function too as otherwise installation on Alma will fail.