### PR TITLE
Replace ifconfig.co with ipv6-test

### DIFF
--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -627,9 +627,9 @@ function installOpenVPN() {
 
 		# Behind NAT, we'll default to the publicly reachable IPv4/IPv6.
 		if [[ $IPV6_SUPPORT == "y" ]]; then
-			PUBLIC_IP=$(curl https://ifconfig.co)
+			PUBLIC_IP=$(curl http://v4v6.ipv6-test.com/api/myip.php)
 		else
-			PUBLIC_IP=$(curl -4 https://ifconfig.co)
+			PUBLIC_IP=$(curl -4 http://v4v6.ipv6-test.com/api/myip.php)
 		fi
 		ENDPOINT=${ENDPOINT:-$PUBLIC_IP}
 	fi


### PR DESCRIPTION
The https://ifconfig.co block some countries (eg. Iran) by Cloudflare and when you run the `curl ifconfig.co`, you will be getting `error code: 1020`

I replace the ifconfig.co with ipv6-test to solve this issue

(Please add hacktoberfest labels to this PR and if you want to merge it hacktoberfest-accepted and hacktoberfest labels)