### PR TITLE
Enable oracle-epel-release for Oracle Linux

### DIFF
--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -675,8 +675,9 @@ function installOpenVPN() {
 			yum install -y epel-release
 			yum install -y openvpn iptables openssl wget ca-certificates curl tar 'policycoreutils-python*'
 		elif [[ $OS == 'oracle' ]]; then
-			yum install -y 'oracle-epel-release-*'
-			yum install -y openvpn iptables openssl wget ca-certificates curl tar 'policycoreutils-python*'
+			yum install -y oracle-epel-release-el8
+			yum-config-manager --enable ol8_developer_EPEL
+			yum install -y openvpn iptables openssl wget ca-certificates curl tar policycoreutils-python-utils
 		elif [[ $OS == 'amzn' ]]; then
 			amazon-linux-extras install -y epel
 			yum install -y openvpn iptables openssl wget ca-certificates curl


### PR DESCRIPTION
In Oracle Linux after installing oracle-epel-release it's necessary to enable this repository:

`yum-config-manager --enable ol8_developer_EPEL`

The error did not occur for users who had previously installed the epel repository correctly.
This commit fix that oversight.
Otherwise, the openvpn, policycoreutils-python-utils packages will not be installed.

I reproduced this bug in the Oracle-Linux-8.4-2021.10.04-0 image.