### PR TITLE
revokeClient: Do not remove revoked client record from index.txt

### DIFF
--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -1187,7 +1187,6 @@ function revokeClient() {
 	rm -f "/root/$CLIENT.ovpn"
 	sed -i "/^$CLIENT,.*/d" /etc/openvpn/ipp.txt
 	cp /etc/openvpn/easy-rsa/pki/index.txt{,.bk}
-	sed -i -e '/^[R]/d' /etc/openvpn/easy-rsa/pki/index.txt
 
 	echo ""
 	echo "Certificate for client $CLIENT revoked."


### PR DESCRIPTION
Deleting a revoked (^R) client record from index.txt means that the
client will not be listed in the Certificate Revocation List.  This
effectively "unrevokes" the client and allows the client to continue
using the VPN.

Signed-off-by: Richard T Bonhomme <tincantech@protonmail.com>