### PR TITLE
ncp-cipher option has renamed to data-cipher

### DIFF
--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -891,7 +891,7 @@ cert $SERVER_NAME.crt
 key $SERVER_NAME.key
 auth $HMAC_ALG
 cipher $CIPHER
-ncp-ciphers $CIPHER
+data-ciphers $CIPHER
 tls-server
 tls-version-min 1.2
 tls-cipher $CC_CIPHER


### PR DESCRIPTION
At startup openvpn prints "This option was renamed in openvpn 2.5". In debian, arch, etc its 2.5+ versions of openvpn package in repos already, that's why we need to change this option. https://build.openvpn.net/man/openvpn-2.5/openvpn.8.html