### PR TITLE
feat: add flag for creation or not of new client after install

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ If you want to customise your installation, you can export them or specify them 
 - `MULTI_CLIENT=n`
 - `CLIENT_CERT_DURATION_DAYS=3650`
 - `SERVER_CERT_DURATION_DAYS=3650`
+- `NEW_CLIENT=y` (set to `n` to skip client creation after installation)
 
 If the server is behind NAT, you can specify its endpoint with the `ENDPOINT` variable. If the endpoint is the public IP address which it is behind, you can use `ENDPOINT=$(curl -4 ifconfig.co)` (the script will default to this). The endpoint can be an IPv4 or a domain.
 

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -990,6 +990,7 @@ function installOpenVPN() {
 		CLIENT_CERT_DURATION_DAYS=${CLIENT_CERT_DURATION_DAYS:-$DEFAULT_CERT_VALIDITY_DURATION_DAYS}
 		SERVER_CERT_DURATION_DAYS=${SERVER_CERT_DURATION_DAYS:-$DEFAULT_CERT_VALIDITY_DURATION_DAYS}
 		CONTINUE=${CONTINUE:-y}
+		NEW_CLIENT=${NEW_CLIENT:-y}
 
 		if [[ -z $ENDPOINT ]]; then
 			ENDPOINT=$(resolvePublicIP)
@@ -1517,9 +1518,13 @@ verb 3" >>/etc/openvpn/server/client-template.txt
 	fi
 
 	# Generate the custom client.ovpn
-	log_info "Generating first client certificate..."
-	newClient
-	log_success "If you want to add more clients, you simply need to run this script another time!"
+	if [[ $NEW_CLIENT == "n" ]]; then
+		log_info "No clients added. To add clients, simply run the script again."
+	else
+		log_info "Generating first client certificate..."
+		newClient
+		log_success "If you want to add more clients, you simply need to run this script another time!"
+	fi
 }
 
 # Helper function to get the home directory for storing client configs


### PR DESCRIPTION
Add a flag `NEW_CLIENT` so that the user can choose whether or not he wishes to create a new user after installation.
It is specially useful on headless installations, when upgrading to a different server, but keeping old credentials.
It does not change any defaults, so if no flag is passed, it still creates the new user.

