### PR TITLE
Use --genkey secret filename instead

### DIFF
--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -742,11 +742,11 @@ function installOpenVPN() {
 		case $TLS_SIG in
 		1)
 			# Generate tls-crypt key
-			openvpn --genkey --secret /etc/openvpn/tls-crypt.key
+			openvpn --genkey secret /etc/openvpn/tls-crypt.key
 			;;
 		2)
 			# Generate tls-auth key
-			openvpn --genkey --secret /etc/openvpn/tls-auth.key
+			openvpn --genkey secret /etc/openvpn/tls-auth.key
 			;;
 		esac
 	else


### PR DESCRIPTION
Fix for:
WARNING: Using --genkey --secret filename is DEPRECATED.  Use --genkey secret filename instead.

https://community.openvpn.net/openvpn/wiki/DeprecatedOptions#Option:--secret

Status 	Removed
Deprecated in: 	OpenVPN v2.4
Removed in: 	OpenVPN v2.5
Affects: 	--genkey
Result if used: 	User Warning printed
Replaced by: 	secret (No leading double dash)
Examples: 	Use --genkey secret filename
Notes: