### PR TITLE
Fixed issue with ifconfig.co

### DIFF
--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -628,11 +628,11 @@ function installOpenVPN() {
 		# Behind NAT, we'll default to the publicly reachable IPv4/IPv6.
 		if [[ $IPV6_SUPPORT == "y" ]]; then
 			if ! PUBLIC_IP=$(curl -f --retry 5 --retry-connrefused https://ifconfig.co) ; then
-				PUBLIC_IP=$(dig -6 TXT +short o-o.myaddr.l.google.com @ns1.google.com)
+				PUBLIC_IP=$(dig -6 TXT +short o-o.myaddr.l.google.com @ns1.google.com | tr -d '"')
 			fi
 		else
 			if ! PUBLIC_IP=$(curl -f --retry 5 --retry-connrefused -4 https://ifconfig.co) ; then
-				PUBLIC_IP=$(dig +short myip.opendns.com @resolver1.opendns.com)
+				PUBLIC_IP=$(dig -4 TXT +short o-o.myaddr.l.google.com @ns1.google.com | tr -d '"')
 			fi
 		fi
 		ENDPOINT=${ENDPOINT:-$PUBLIC_IP}

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -627,9 +627,13 @@ function installOpenVPN() {
 
 		# Behind NAT, we'll default to the publicly reachable IPv4/IPv6.
 		if [[ $IPV6_SUPPORT == "y" ]]; then
-			PUBLIC_IP=$(curl --retry 5 --retry-connrefused https://ifconfig.co)
+			if ! PUBLIC_IP=$(curl -f --retry 5 --retry-connrefused https://ifconfig.co) ; then
+				PUBLIC_IP=$(dig -6 TXT +short o-o.myaddr.l.google.com @ns1.google.com)
+			fi
 		else
-			PUBLIC_IP=$(curl --retry 5 --retry-connrefused -4 https://ifconfig.co)
+			if ! PUBLIC_IP=$(curl -f --retry 5 --retry-connrefused -4 https://ifconfig.co) ; then
+				PUBLIC_IP=$(dig +short myip.opendns.com @resolver1.opendns.com)
+			fi
 		fi
 		ENDPOINT=${ENDPOINT:-$PUBLIC_IP}
 	fi


### PR DESCRIPTION
Hi all,

I am using this script on some VMs in Azure. It worked quite well for a while but stopped working yesterday. The issue is that when obtaining the public IP address, the `https://ifconfig.co` is now behind the Cloudfare, so the CURL request to it fails with HTTP code 503 and in response is this HTML instead of an IP address:
![image](https://user-images.githubusercontent.com/2153835/204925933-afaf8306-6576-438d-8a29-110bade33916.png)

This PR comes with a fallback, whenever the `https://ifconfig.co` will not be useable for any reason, it will utilize the Google DNS service for those purposes.

I have tested it on Azure VMs and locally and it is working just fine.