### PR TITLE
Fix the wrong client config when the certificate contains END string

### DIFF
--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -1125,7 +1125,7 @@ function newClient() {
 		echo "</ca>"
 
 		echo "<cert>"
-		awk '/BEGIN/,/END/' "/etc/openvpn/easy-rsa/pki/issued/$CLIENT.crt"
+		awk '/BEGIN/,/END CERTIFICATE/' "/etc/openvpn/easy-rsa/pki/issued/$CLIENT.crt"
 		echo "</cert>"
 
 		echo "<key>"


### PR DESCRIPTION
When the generated certificate contains the string END, then the client config will not be correct, user cannot connect the server for the following error:

```
OpenSSL: error:0908F070:PEM routines:get_header_and_data:short header
```

To fix it, change the awk filter option from "END" to "END CERTIFICATE".