### PR TITLE
Replace ifconfig with freeipapi

### DIFF
--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -627,9 +627,9 @@ function installOpenVPN() {
 
 		# Behind NAT, we'll default to the publicly reachable IPv4/IPv6.
 		if [[ $IPV6_SUPPORT == "y" ]]; then
-			PUBLIC_IP=$(curl --retry 5 --retry-connrefused https://freeipapi.com/ip)
+			PUBLIC_IP=$(curl --retry 5 --retry-connrefused freeipapi.com)
 		else
-			PUBLIC_IP=$(curl --retry 5 --retry-connrefused -4 https://freeipapi.com/ip)
+			PUBLIC_IP=$(curl --retry 5 --retry-connrefused -4 freeipapi.com)
 		fi
 		ENDPOINT=${ENDPOINT:-$PUBLIC_IP}
 	fi

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -627,9 +627,9 @@ function installOpenVPN() {
 
 		# Behind NAT, we'll default to the publicly reachable IPv4/IPv6.
 		if [[ $IPV6_SUPPORT == "y" ]]; then
-			PUBLIC_IP=$(curl --retry 5 --retry-connrefused https://ifconfig.co)
+			PUBLIC_IP=$(curl --retry 5 --retry-connrefused https://freeipapi.com/ip)
 		else
-			PUBLIC_IP=$(curl --retry 5 --retry-connrefused -4 https://ifconfig.co)
+			PUBLIC_IP=$(curl --retry 5 --retry-connrefused -4 https://freeipapi.com/ip)
 		fi
 		ENDPOINT=${ENDPOINT:-$PUBLIC_IP}
 	fi


### PR DESCRIPTION
I've seen this issue in the past and also here that `ifconfig.co` is not working with some of the cloud servers like Hetzner.

I replaced it with another stable IP information service (freeipapi.com)

here is one issue from the past:

https://github.com/angristan/openvpn-install/issues/1039

