### PR TITLE
fix syntax error on Rocky Linux check version

### DIFF
--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -57,7 +57,7 @@ function checkOS() {
 		fi
 		if [[ $ID == "centos" || $ID == "rocky" || $ID == "almalinux" ]]; then
 			OS="centos"
-			if [[ $VERSION_ID -lt 7 ]]; then
+			if [[ ${VERSION_ID%.*} -lt 7 ]]; then
 				echo "⚠️ Your version of CentOS is not supported."
 				echo ""
 				echo "The script only support CentOS 7 and CentOS 8."


### PR DESCRIPTION
Fix this issue: openvpn-install.sh: ligne 60: [[: 8.8 : erreur de syntaxe : opérateur arithmétique non valable (le symbole erroné est « .8 »)

Tested on Rocky Linux 8.8