### PR TITLE
Fix Public IP detection - Fix issue when seeip.org is unreachable #1241

### DIFF
--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -229,17 +229,17 @@ function resolvePublicIP() {
 
 	# If there is no public ip yet, we'll try to solve it using: https://api.seeip.org
 	if [[ -z $PUBLIC_IP ]]; then
-		PUBLIC_IP=$(curl -f -m 5 -sS --retry 2 --retry-connrefused $CURL_IP_VERSION_FLAG https://api.seeip.org 2>/dev/null)
+		PUBLIC_IP=$(curl -f -m 5 -sS --retry 2 --retry-connrefused "$CURL_IP_VERSION_FLAG" https://api.seeip.org 2>/dev/null)
 	fi
 
 	# If there is no public ip yet, we'll try to solve it using: https://ifconfig.me
 	if [[ -z $PUBLIC_IP ]]; then
-		PUBLIC_IP=$(curl -f -m 5 -sS --retry 2 --retry-connrefused $CURL_IP_VERSION_FLAG https://ifconfig.me 2>/dev/null)
+		PUBLIC_IP=$(curl -f -m 5 -sS --retry 2 --retry-connrefused "$CURL_IP_VERSION_FLAG" https://ifconfig.me 2>/dev/null)
 	fi
 
 	# If there is no public ip yet, we'll try to solve it using: https://api.ipify.org
 	if [[ -z $PUBLIC_IP ]]; then
-		PUBLIC_IP=$(curl -f -m 5 -sS --retry 2 --retry-connrefused $CURL_IP_VERSION_FLAG https://api.ipify.org 2>/dev/null)
+		PUBLIC_IP=$(curl -f -m 5 -sS --retry 2 --retry-connrefused "$CURL_IP_VERSION_FLAG" https://api.ipify.org 2>/dev/null)
 	fi
 
 	# If there is no public ip yet, we'll try to solve it using: ns1.google.com

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -227,9 +227,9 @@ function resolvePublicIP() {
 		DIG_IP_VERSION_FLAG="-6"
 	fi
 
-	# If there is no public ip yet, we'll try to solve it using: https://ip.seeip.org
+	# If there is no public ip yet, we'll try to solve it using: https://api.seeip.org
 	if [[ -z $PUBLIC_IP ]]; then
-		PUBLIC_IP=$(curl -f -m 5 -sS --retry 2 --retry-connrefused $CURL_IP_VERSION_FLAG https://ip.seeip.org 2>/dev/null)
+		PUBLIC_IP=$(curl -f -m 5 -sS --retry 2 --retry-connrefused $CURL_IP_VERSION_FLAG https://api.seeip.org 2>/dev/null)
 	fi
 
 	# If there is no public ip yet, we'll try to solve it using: https://ifconfig.me

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -283,9 +283,12 @@ function installQuestions() {
 		echo "It seems this server is behind NAT. What is its public IPv4 address or hostname?"
 		echo "We need it for the clients to connect to the server."
 
+		if [[ -z $ENDPOINT ]]; then
+			DEFAULT_ENDPOINT=$(resolvePublicIP)
+		fi
+
 		until [[ $ENDPOINT != "" ]]; do
-			PUBLIC_IP=$(resolvePublicIP)
-			read -rp "Public IPv4 address or hostname: " -e -i "$PUBLIC_IP" ENDPOINT
+			read -rp "Public IPv4 address or hostname: " -e -i "$DEFAULT_ENDPOINT" ENDPOINT
 		done
 	fi
 
@@ -664,9 +667,9 @@ function installOpenVPN() {
 		PASS=${PASS:-1}
 		CONTINUE=${CONTINUE:-y}
 
-		until [[ $ENDPOINT != "" ]]; do
+		if [[ -z $ENDPOINT ]]; then
 			ENDPOINT=$(resolvePublicIP)
-		done
+		fi
 	fi
 
 	# Run setup questions first, and set other variables if auto-install

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -229,17 +229,17 @@ function resolvePublicIP() {
 
 	# If there is no public ip yet, we'll try to solve it using: https://ip.seeip.org
 	if [[ -z $PUBLIC_IP ]]; then
-		PUBLIC_IP=$(curl -f -m 5 -sS --retry 5 --retry-connrefused $CURL_IP_VERSION_FLAG https://ip.seeip.org 2>/dev/null)
+		PUBLIC_IP=$(curl -f -m 5 -sS --retry 2 --retry-connrefused $CURL_IP_VERSION_FLAG https://ip.seeip.org 2>/dev/null)
 	fi
 
 	# If there is no public ip yet, we'll try to solve it using: https://ifconfig.me
 	if [[ -z $PUBLIC_IP ]]; then
-		PUBLIC_IP=$(curl -f -m 5 -sS --retry 5 --retry-connrefused $CURL_IP_VERSION_FLAG https://ifconfig.me 2>/dev/null)
+		PUBLIC_IP=$(curl -f -m 5 -sS --retry 2 --retry-connrefused $CURL_IP_VERSION_FLAG https://ifconfig.me 2>/dev/null)
 	fi
 
 	# If there is no public ip yet, we'll try to solve it using: https://api.ipify.org
 	if [[ -z $PUBLIC_IP ]]; then
-		PUBLIC_IP=$(curl -f -m 5 -sS --retry 5 --retry-connrefused $CURL_IP_VERSION_FLAG https://api.ipify.org 2>/dev/null)
+		PUBLIC_IP=$(curl -f -m 5 -sS --retry 2 --retry-connrefused $CURL_IP_VERSION_FLAG https://api.ipify.org 2>/dev/null)
 	fi
 
 	# If there is no public ip yet, we'll try to solve it using: ns1.google.com

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -248,7 +248,7 @@ function resolvePublicIP() {
 	fi
 
 	if [[ -z $PUBLIC_IP ]]; then
-		>&2 echo "Couldn't solve the public IP"
+		echo >&2 echo "Couldn't solve the public IP"
 		exit 1
 	fi
 


### PR DESCRIPTION
The script does work when seeip.org is unreachable, so I changed the policy to define the public IP.

It solves the issue #1241

## CHANGELOG

### Added

- Timeout limit on each try to solve the IP to avoid long waits;
- Extra public IP providers as failovers;

### Changed

- the script only will try to solve an IP if the ENDPOINT is empty;

### Removed

- Unneeded output of CURL commands on IP detection;
- Duplicated code;

