### PR TITLE
Allow custom certificate duration when creating clients

### DIFF
--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -862,6 +862,7 @@ function installOpenVPN() {
 		CUSTOMIZE_ENC=${CUSTOMIZE_ENC:-n}
 		CLIENT=${CLIENT:-client}
 		PASS=${PASS:-1}
+		DAYS_VALID=${DAYS_VALID:-3650}
 		CONTINUE=${CONTINUE:-y}
 
 		if [[ -z $ENDPOINT ]]; then
@@ -881,6 +882,7 @@ function installOpenVPN() {
 		log_info "  CUSTOMIZE_ENC=$CUSTOMIZE_ENC"
 		log_info "  CLIENT=$CLIENT"
 		log_info "  PASS=$PASS"
+		log_info "  DAYS_VALID=$DAYS_VALID"
 	fi
 
 	# Run setup questions first, and set other variables if auto-install
@@ -1326,9 +1328,11 @@ function newClient() {
 		read -rp "Client name: " -e CLIENT
 	done
 
-	log_menu ""
-	log_prompt "How many days should the client be valid for?"
-	read -rp "Enter the number of days (default is 3650, which is about 10 years): " -e -i 3650 DAYS_VALID
+	if [[ -z $DAYS_VALID ]]; then
+		log_menu ""
+		log_prompt "How many days should the client certificate be valid for?"
+		read -rp "Certificate validity (days): " -e -i 3650 DAYS_VALID
+	fi
 
 	log_menu ""
 	log_prompt "Do you want to protect the configuration file with a password?"

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -1327,6 +1327,10 @@ function newClient() {
 	done
 
 	log_menu ""
+	log_prompt "How many days should the client be valid for?"
+	read -rp "Enter the number of days (default is 3650, which is about 10 years): " -e -i 3650 DAYS_VALID
+
+	log_menu ""
 	log_prompt "Do you want to protect the configuration file with a password?"
 	log_prompt "(e.g. encrypt the private key with a password)"
 	log_menu "   1) Add a passwordless client"
@@ -1343,7 +1347,7 @@ function newClient() {
 	else
 		cd /etc/openvpn/easy-rsa/ || return
 		log_info "Generating client certificate..."
-		export EASYRSA_CERT_EXPIRE=$CERT_VALIDITY_DAYS
+		export EASYRSA_CERT_EXPIRE=$DAYS_VALID
 		case $PASS in
 		1)
 			run_cmd "Building client certificate" ./easyrsa --batch build-client-full "$CLIENT" nopass
@@ -1353,7 +1357,7 @@ function newClient() {
 			./easyrsa --batch build-client-full "$CLIENT"
 			;;
 		esac
-		log_success "Client $CLIENT added."
+		log_success "Client $CLIENT added and is valid for $DAYS_VALID days."
 	fi
 
 	# Home directory of the user, where the client configuration will be written


### PR DESCRIPTION
For those who need it, the script asks for how many days the new client should be valid. This defaults to 3650 days. Then it sets the ```EASYRSA_CERT_EXPIRE``` variable accordingly.

This script is meant to be simple which means it is for those who are not tech-savvy to handle the complex task of installing and configuring OpenVPN.

However if the user has a large number of clients and all of them are valid for 10 years, it is very hard to keep track of them. This PR helps them to set a reasonable validity period, while the default is the same.
<!---
❗️ Please read ❗️
➡️ Please make sure you've followed the guidelines: https://github.com/angristan/openvpn-install#contributing
✅ Please make sure your changes are tested and working
🗣️ Please avoid large PRs, and discuss changes in a GitHub issue first
✋ If the changes are too big and not in line with the project, they will probably be rejected. Remember that this script is meant to be simple and easy to use.
--->
