### PR TITLE
Add support for Amazon Linux 2023 out of the box

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,18 +132,19 @@ export PASS="1"
 
 The script supports these Linux distributions:
 
-|                    | Support |
-| ------------------ | ------- |
-| AlmaLinux 8        | ✅       |
-| Amazon Linux 2     | ✅       |
-| Arch Linux         | ✅       |
-| CentOS 7           | ✅       |
-| CentOS Stream >= 8 | ✅ 🤖     |
-| Debian >= 10       | ✅ 🤖     |
-| Fedora >= 35       | ✅ 🤖     |
-| Oracle Linux 8     | ✅       |
-| Rocky Linux 8      | ✅       |
-| Ubuntu >= 18.04    | ✅ 🤖     |
+|                        | Support |
+| ---------------------- | ------- |
+| AlmaLinux 8            | ✅      |
+| Amazon Linux 2         | ✅      |
+| Amazon Linux >= 2023.6 | ✅      |
+| Arch Linux             | ✅      |
+| CentOS 7               | ✅      |
+| CentOS Stream >= 8     | ✅ 🤖   |
+| Debian >= 10           | ✅ 🤖   |
+| Fedora >= 35           | ✅ 🤖   |
+| Oracle Linux 8         | ✅      |
+| Rocky Linux 8          | ✅      |
+| Ubuntu >= 18.04        | ✅ 🤖   |
 
 To be noted:
 

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -77,7 +77,7 @@ function checkOS() {
 		if [[ $ID == "amzn" ]]; then
 			if [[ $VERSION_ID == "2" ]]; then
 				OS="amzn"
-			elif [  "$(echo $PRETTY_NAME | cut -c 1-19)" == "Amazon Linux 2023.6" ]; then
+			elif [[ "$(echo $PRETTY_NAME | cut -c 1-19)" == "Amazon Linux 2023.6" ]]; then
 				OS="amzn2023"
 			else
 				echo "⚠️ Your version of Amazon Linux is not supported."

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -77,12 +77,12 @@ function checkOS() {
 		if [[ $ID == "amzn" ]]; then
 			if [[ $VERSION_ID == "2" ]]; then
 				OS="amzn"
-			elif [[ "$(echo $PRETTY_NAME | cut -c 1-19)" == "Amazon Linux 2023.6" ]]; then
+			elif [[ "$(echo $PRETTY_NAME | cut -c 1-18)" == "Amazon Linux 2023." ]] && [[ "$(echo $PRETTY_NAME | cut -c 19)" -ge 6 ]]; then
 				OS="amzn2023"
 			else
 				echo "⚠️ Your version of Amazon Linux is not supported."
 				echo ""
-				echo "The script only support Amazon Linux 2 or Amazon Linux 2023.6"
+				echo "The script only support Amazon Linux 2 or Amazon Linux 2023.6+"
 				echo ""
 				exit 1
 			fi

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -77,7 +77,7 @@ function checkOS() {
 		if [[ $ID == "amzn" ]]; then
 			if [[ $VERSION_ID == "2" ]]; then
 				OS="amzn"
-			elif [[ "$(echo $PRETTY_NAME | cut -c 1-18)" == "Amazon Linux 2023." ]] && [[ "$(echo $PRETTY_NAME | cut -c 19)" -ge 6 ]]; then
+			elif [[ "$(echo "$PRETTY_NAME" | cut -c 1-18)" == "Amazon Linux 2023." ]] && [[ "$(echo "$PRETTY_NAME" | cut -c 19)" -ge 6 ]]; then
 				OS="amzn2023"
 			else
 				echo "⚠️ Your version of Amazon Linux is not supported."

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -77,12 +77,12 @@ function checkOS() {
 		if [[ $ID == "amzn" ]]; then
 			if [[ $VERSION_ID == "2" ]]; then
 				OS="amzn"
-			elif [[ $VERSION_ID == "2023" ]]; then
+			elif [  "$(echo $PRETTY_NAME | cut -c 1-19)" == "Amazon Linux 2023.6" ]; then
 				OS="amzn2023"
 			else
 				echo "⚠️ Your version of Amazon Linux is not supported."
 				echo ""
-				echo "The script only support Amazon Linux 2."
+				echo "The script only support Amazon Linux 2 or Amazon Linux 2023.6"
 				echo ""
 				exit 1
 			fi

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -75,8 +75,11 @@ function checkOS() {
 			fi
 		fi
 		if [[ $ID == "amzn" ]]; then
-			OS="amzn"
-			if [[ $VERSION_ID != "2" ]]; then
+			if [[ $VERSION_ID == "2" ]]; then
+				OS="amzn"
+			elif [[ $VERSION_ID == "2023" ]]; then
+				OS="amzn2023"
+			else
 				echo "⚠️ Your version of Amazon Linux is not supported."
 				echo ""
 				echo "The script only support Amazon Linux 2."
@@ -719,6 +722,8 @@ function installOpenVPN() {
 		elif [[ $OS == 'amzn' ]]; then
 			amazon-linux-extras install -y epel
 			yum install -y openvpn iptables openssl wget ca-certificates curl
+		elif [[ $OS == 'amzn2023' ]]; then
+			dnf install -y openvpn iptables openssl wget ca-certificates
 		elif [[ $OS == 'fedora' ]]; then
 			dnf install -y openvpn iptables openssl wget ca-certificates curl policycoreutils-python-utils
 		elif [[ $OS == 'arch' ]]; then
@@ -958,7 +963,7 @@ verb 3" >>/etc/openvpn/server.conf
 	fi
 
 	# Finally, restart and enable OpenVPN
-	if [[ $OS == 'arch' || $OS == 'fedora' || $OS == 'centos' || $OS == 'oracle' ]]; then
+	if [[ $OS == 'arch' || $OS == 'fedora' || $OS == 'centos' || $OS == 'oracle' || $OS == 'amzn2023' ]]; then
 		# Don't modify package-provided service
 		cp /usr/lib/systemd/system/openvpn-server@.service /etc/systemd/system/openvpn-server@.service
 
@@ -1376,3 +1381,4 @@ if [[ -e /etc/openvpn/server.conf && $AUTO_INSTALL != "y" ]]; then
 else
 	installOpenVPN
 fi
+

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -1381,4 +1381,3 @@ if [[ -e /etc/openvpn/server.conf && $AUTO_INSTALL != "y" ]]; then
 else
 	installOpenVPN
 fi
-


### PR DESCRIPTION
<!---
❗️ Please read ❗️
➡️ Please make sure you've followed the guidelines: https://github.com/angristan/openvpn-install#contributing
✅ Please make sure your changes are tested and working
🗣️ Please avoid large PRs, and discuss changes in a GitHub issue first
✋ If the changes are too big and not in line with the project, they will probably be rejected. Remember that this script is meant to be simple and easy to use.
--->

This PR aims to address [issue 1230](https://github.com/angristan/openvpn-install/issues/1230): Support for more recent versions of Amazon Linux (2023.6).

It also incorporates the seeip.org unreachable fix from [#1252](https://github.com/angristan/openvpn-install/pull/1252/files), which aims to address [Issue 1241](https://github.com/angristan/openvpn-install/issues/1241).

Changes have been tested on AWS AL2023 2023.6 (ami-050cd642fd83388e4), where the following complete successfully:
1. Script installation
1. Local client connection via generated .opvn file
1. Local IP address matches remote host IP (via api.seeip.org).

