### PR TITLE
修复腾讯云tencentos系统安装时报错

### DIFF
--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -65,6 +65,16 @@ function checkOS() {
 				exit 1
 			fi
 		fi
+		if [[ $ID == "tencentos" ]]; then
+			OS="centos"
+			if [[ ${VERSION_ID%.*} -lt 3 ]]; then
+				echo "⚠️ Your version of CentOS is not supported."
+				echo ""
+				echo "The script only support CentOS 7 and CentOS 8."
+				echo ""
+				exit 1
+			fi
+		fi
 		if [[ $ID == "ol" ]]; then
 			OS="oracle"
 			if [[ ! $VERSION_ID =~ (8) ]]; then


### PR DESCRIPTION
修复腾讯云tencentos系统安装时报错

脚本要识别腾讯云系统时会报错,判断的条件也会出错,
当识别tencentos时,判断系统版本 OS="centos"
修复代码:
if [[ $ID == "tencentos" ]]; then
			OS="centos"
			if [[ ${VERSION_ID%.*} -lt 3 ]]; then
