### PR TITLE
Add support for OpenVPN 2.6 on Amazon Linux 2 by enabling Fedora COPR Repository

### DIFF
--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -720,6 +720,13 @@ function installOpenVPN() {
 			yum-config-manager --enable ol8_developer_EPEL
 			yum install -y openvpn iptables openssl wget ca-certificates curl tar policycoreutils-python-utils
 		elif [[ $OS == 'amzn' ]]; then
+			# Install and configure Fedora COPR repository for OpenVPN
+			# This ensures we get the latest stable OpenVPN 2.6 releases
+			# 1. Install the COPR plugin for yum package manager
+			# 2. Enable the specific repository maintained by dsommers for OpenVPN 2.6
+			# Reference: https://community.openvpn.net/openvpn/wiki/OpenvpnSoftwareRepos#UsingFedoraCopr
+			yum install -y yum-plugin-copr
+			yum copr enable -y dsommers/openvpn-release-2.6
 			amazon-linux-extras install -y epel
 			yum install -y openvpn iptables openssl wget ca-certificates curl
 		elif [[ $OS == 'amzn2023' ]]; then


### PR DESCRIPTION
# Description
This PR adds support for the latest stable OpenVPN 2.6 releases on Amazon Linux 2 by utilizing the Fedora COPR repository maintained by dsommers. This ensures Amazon Linux 2 users have access to the most current and secure version of OpenVPN.

# Changes
- Added installation of `yum-plugin-copr` package to support the COPR repository
- Enabled the specific repository (`dsommers/openvpn-release-2.6`) for OpenVPN 2.6
- Added clear comments explaining the purpose of these changes
- Included a reference URL to the official OpenVPN software repository documentation

# Why this matters
Amazon Linux 2 users previously did not have access to the latest OpenVPN releases through standard repositories. This change improves security and feature availability by providing access to the most current version.

# Testing
- Tested on Amazon Linux 2 instance
- Verified successful installation of OpenVPN 2.6
- Confirmed functionality with client connections

![image](https://github.com/user-attachments/assets/0bdbf1ec-0aea-4c11-b598-35661f6c2a68)


The change is minimal and focused only on the Amazon Linux 2 installation path.