### PR TITLE
ci: prevent duplicate workflow runs

### DIFF
--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -1,10 +1,15 @@
 ---
 on:
   push:
+    branches: [master]
   pull_request:
   workflow_dispatch:
 
 name: Docker Test
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,14 @@
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+    branches: [master]
+  pull_request:
+  workflow_dispatch:
 
 name: Lint
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- Restrict `push` trigger to `master` branch only (feature branch pushes won't trigger CI)
- Add concurrency groups to cancel redundant runs when new commits are pushed
- Works correctly with fork PRs using standard `pull_request` event