### PR TITLE
feat: add certificate renewal functionality

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -8,6 +8,14 @@ You can, of course, it's even recommended, update the `openvpn` package with you
 
 ---
 
+**Q:** How do I renew certificates before they expire?
+
+**A:** Run the script again and select "Renew certificates" from the menu. You can renew either client certificates or the server certificate. The script will show you the current expiration date for each certificate and let you choose a new validity period (default: 3650 days / 10 years).
+
+For client renewals, a new `.ovpn` file will be generated that you need to distribute to the client. For server renewals, the OpenVPN service will need to be restarted (the script will prompt you).
+
+---
+
 **Q:** How do I check for DNS leaks?
 
 **A:** Go to [browserleaks.com](https://browserleaks.com/dns) or [ipleak.net](https://ipleak.net/) (both perform IPv4 and IPv6 check) with your browser. Your IP should not show up (test without and without the VPN). The DNS servers should be the ones you selected during the setup, not your IP address nor your ISP's DNS servers' addresses.

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ When OpenVPN is installed, you can run the script again, and you will get the ch
 
 - Add a client
 - Remove a client
+- Renew certificates (client or server)
 - Uninstall OpenVPN
 
 In your home directory, you will have `.ovpn` files. These are the client configuration files. Download them from your server and connect using your favorite OpenVPN client.
@@ -113,6 +114,7 @@ export PASS="1"
 ## Features
 
 - Installs and configures a ready-to-use OpenVPN server
+- Certificate renewal for both client and server certificates
 - Uses [official OpenVPN repositories](https://community.openvpn.net/openvpn/wiki/OpenvpnSoftwareRepos) when possible for the latest stable releases
 - Iptables rules and forwarding managed in a seamless way
 - If needed, the script can cleanly remove OpenVPN, including configuration and iptables rules

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -1530,7 +1530,7 @@ function renewClient() {
 
 	# Renew the certificate (keeps the same private key)
 	export EASYRSA_CERT_EXPIRE=$days_valid
-	run_cmd "Renewing certificate" ./easyrsa --batch renew "$CLIENT" nopass
+	run_cmd "Renewing certificate" ./easyrsa --batch renew "$CLIENT"
 
 	# Revoke the old certificate
 	run_cmd "Revoking old certificate" ./easyrsa --batch revoke-renewed "$CLIENT"
@@ -1588,7 +1588,7 @@ function renewServer() {
 
 	# Renew the certificate (keeps the same private key)
 	export EASYRSA_CERT_EXPIRE=$days_valid
-	run_cmd "Renewing certificate" ./easyrsa --batch renew "$server_name" nopass
+	run_cmd "Renewing certificate" ./easyrsa --batch renew "$server_name"
 
 	# Revoke the old certificate
 	run_cmd "Revoking old certificate" ./easyrsa --batch revoke-renewed "$server_name"

--- a/test/server-entrypoint.sh
+++ b/test/server-entrypoint.sh
@@ -105,7 +105,7 @@ echo "Original client certificate serial: $ORIG_CERT_SERIAL"
 # Test client certificate renewal using the script
 echo "Testing client certificate renewal..."
 RENEW_OUTPUT="/tmp/renew-client-output.log"
-(MENU_OPTION=3 RENEW_OPTION=1 CLIENTNUMBER=1 bash /tmp/openvpn-install.sh) 2>&1 | tee "$RENEW_OUTPUT" || true
+(MENU_OPTION=3 RENEW_OPTION=1 CLIENTNUMBER=1 DAYS_VALID=3650 bash /tmp/openvpn-install.sh) 2>&1 | tee "$RENEW_OUTPUT" || true
 
 # Verify renewal succeeded
 if grep -q "Certificate for client testclient renewed" "$RENEW_OUTPUT"; then
@@ -185,7 +185,7 @@ echo "Original server certificate serial: $ORIG_SERVER_SERIAL"
 # Test server certificate renewal
 echo "Testing server certificate renewal..."
 RENEW_SERVER_OUTPUT="/tmp/renew-server-output.log"
-(MENU_OPTION=3 RENEW_OPTION=2 CONTINUE=y bash /tmp/openvpn-install.sh) 2>&1 | tee "$RENEW_SERVER_OUTPUT" || true
+(MENU_OPTION=3 RENEW_OPTION=2 CONTINUE=y DAYS_VALID=3650 bash /tmp/openvpn-install.sh) 2>&1 | tee "$RENEW_SERVER_OUTPUT" || true
 
 # Verify renewal succeeded
 if grep -q "Server certificate renewed successfully" "$RENEW_SERVER_OUTPUT"; then


### PR DESCRIPTION
## Summary

- Add certificate renewal for both client and server certificates
- Allow custom validity period during renewal (prompts user, defaults to 3650 days)
- Show expiry info inline in menus (e.g., "Renew the server certificate (expires in 3542 days)")
- Regenerate `.ovpn` files after client renewal
- Restart OpenVPN service after server renewal
- Extract reusable helper functions to reduce code duplication
- Add robust input validation and error handling

## New menu option

```
What do you want to do?
   1) Add a new user
   2) Revoke existing user
   3) Renew certificate        ← NEW
   4) Remove OpenVPN
   5) Exit
```

## Renewal submenu

```
What do you want to renew?
   1) Renew a client certificate
   2) Renew the server certificate (expires in 3542 days)
   3) Back to main menu
```

Client list shows expiry for each:
```
Select the existing client certificate you want to renew
     1) alice (expires in 3542 days)
     2) bob (expires in 30 days)
     3) charlie (EXPIRED 5 days ago)
```

## Helper functions added

Extracted common code into reusable functions:
- `getHomeDir()` - home directory detection
- `regenerateCRL()` - CRL regeneration after cert changes
- `generateClientConfig()` - .ovpn file generation  
- `selectClient()` - client listing with optional expiry display
- `getDaysUntilExpiry()` - certificate expiry calculation
- `formatExpiry()` - human-readable expiry formatting

## Test plan

- [x] Client certificate renewal tested in Docker CI
- [x] Server certificate renewal tested in Docker CI
- [x] Certificate validity verified after renewal (~3650 days)
- [x] VPN connectivity tested with renewed certificate

Closes #974 #1002 #1228 #1060