### PR TITLE
ci: add Renovate for Easy-RSA version updates

### DIFF
--- a/.github/workflows/update-easyrsa-hash.yml
+++ b/.github/workflows/update-easyrsa-hash.yml
@@ -3,7 +3,7 @@ name: Update Easy-RSA SHA256
 on:
   pull_request:
     paths:
-      - 'openvpn-install.sh'
+      - "openvpn-install.sh"
 
 jobs:
   update-hash:

--- a/.github/workflows/update-easyrsa-hash.yml
+++ b/.github/workflows/update-easyrsa-hash.yml
@@ -1,0 +1,46 @@
+name: Update Easy-RSA SHA256
+
+on:
+  pull_request:
+    paths:
+      - 'openvpn-install.sh'
+
+jobs:
+  update-hash:
+    if: startsWith(github.head_ref, 'renovate/')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract version and update SHA256
+        run: |
+          VERSION=$(grep -oP 'EASYRSA_VERSION="\K[^"]+' openvpn-install.sh)
+          echo "Easy-RSA version: $VERSION"
+
+          CURRENT_SHA=$(grep -oP 'EASYRSA_SHA256="\K[^"]+' openvpn-install.sh)
+          echo "Current SHA256: $CURRENT_SHA"
+
+          NEW_SHA=$(curl -sL "https://github.com/OpenVPN/easy-rsa/releases/download/v${VERSION}/EasyRSA-${VERSION}.tgz" | sha256sum | cut -d' ' -f1)
+          echo "New SHA256: $NEW_SHA"
+
+          if [ "$CURRENT_SHA" != "$NEW_SHA" ]; then
+            sed -i "s/EASYRSA_SHA256=\"$CURRENT_SHA\"/EASYRSA_SHA256=\"$NEW_SHA\"/" openvpn-install.sh
+            echo "SHA256 updated"
+            echo "HASH_CHANGED=true" >> $GITHUB_ENV
+          else
+            echo "SHA256 already correct"
+          fi
+
+      - name: Commit changes
+        if: env.HASH_CHANGED == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add openvpn-install.sh
+          git commit -m "chore: update Easy-RSA SHA256 hash"
+          git push

--- a/.github/workflows/update-easyrsa-hash.yml
+++ b/.github/workflows/update-easyrsa-hash.yml
@@ -10,6 +10,9 @@ on:
     paths:
       - "openvpn-install.sh"
 
+permissions:
+  contents: read
+
 jobs:
   update-hash:
     if: startsWith(github.head_ref, 'renovate/')
@@ -49,7 +52,7 @@ jobs:
           if [ "$CURRENT_SHA" != "$NEW_SHA" ]; then
             sed -i "s|EASYRSA_SHA256=\"$CURRENT_SHA\"|EASYRSA_SHA256=\"$NEW_SHA\"|" openvpn-install.sh
             echo "SHA256 updated"
-            echo "HASH_CHANGED=true" >> $GITHUB_ENV
+            echo "HASH_CHANGED=true" >> "$GITHUB_ENV"
           else
             echo "SHA256 already correct"
           fi

--- a/.github/workflows/update-easyrsa-hash.yml
+++ b/.github/workflows/update-easyrsa-hash.yml
@@ -1,7 +1,12 @@
 name: Update Easy-RSA SHA256
 
+# Note: This workflow commits and pushes changes to openvpn-install.sh.
+# Infinite recursion is prevented because pushes made with GITHUB_TOKEN do not trigger workflows.
+# See: https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#preventing-workflow-runs-from-recursively-generating-new-workflow-runs
+
 on:
   pull_request:
+    types: [opened, synchronize]
     paths:
       - "openvpn-install.sh"
 
@@ -20,16 +25,29 @@ jobs:
       - name: Extract version and update SHA256
         run: |
           VERSION=$(grep -oP 'EASYRSA_VERSION="\K[^"]+' openvpn-install.sh)
+          if [ -z "$VERSION" ]; then
+            echo "Error: Failed to extract EASYRSA_VERSION"
+            exit 1
+          fi
           echo "Easy-RSA version: $VERSION"
 
           CURRENT_SHA=$(grep -oP 'EASYRSA_SHA256="\K[^"]+' openvpn-install.sh)
+          if [ -z "$CURRENT_SHA" ]; then
+            echo "Error: Failed to extract EASYRSA_SHA256"
+            exit 1
+          fi
           echo "Current SHA256: $CURRENT_SHA"
 
-          NEW_SHA=$(curl -sL "https://github.com/OpenVPN/easy-rsa/releases/download/v${VERSION}/EasyRSA-${VERSION}.tgz" | sha256sum | cut -d' ' -f1)
+          TARBALL_URL="https://github.com/OpenVPN/easy-rsa/releases/download/v${VERSION}/EasyRSA-${VERSION}.tgz"
+          if ! curl -fsSL "$TARBALL_URL" -o /tmp/easyrsa.tgz; then
+            echo "Error: Failed to download Easy-RSA tarball from $TARBALL_URL"
+            exit 1
+          fi
+          NEW_SHA=$(sha256sum /tmp/easyrsa.tgz | cut -d' ' -f1)
           echo "New SHA256: $NEW_SHA"
 
           if [ "$CURRENT_SHA" != "$NEW_SHA" ]; then
-            sed -i "s/EASYRSA_SHA256=\"$CURRENT_SHA\"/EASYRSA_SHA256=\"$NEW_SHA\"/" openvpn-install.sh
+            sed -i "s|EASYRSA_SHA256=\"$CURRENT_SHA\"|EASYRSA_SHA256=\"$NEW_SHA\"|" openvpn-install.sh
             echo "SHA256 updated"
             echo "HASH_CHANGED=true" >> $GITHUB_ENV
           else
@@ -39,8 +57,12 @@ jobs:
       - name: Commit changes
         if: env.HASH_CHANGED == 'true'
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add openvpn-install.sh
-          git commit -m "chore: update Easy-RSA SHA256 hash"
-          git push
+          if ! git diff --quiet openvpn-install.sh; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add openvpn-install.sh
+            git commit -m "chore: update Easy-RSA SHA256 hash"
+            git push
+          else
+            echo "No changes to commit"
+          fi

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["^openvpn-install\\.sh$"],
+      "matchStrings": [
+        "EASYRSA_VERSION=\"(?<currentValue>\\d+\\.\\d+\\.\\d+)\""
+      ],
+      "depNameTemplate": "OpenVPN/easy-rsa",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^v(?<version>.*)$"
+    }
+  ]
+}

--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,7 @@
   "customManagers": [
     {
       "customType": "regex",
-      "fileMatch": ["^openvpn-install\\.sh$"],
+      "managerFilePatterns": ["/^openvpn-install\\.sh$/"],
       "matchStrings": [
         "EASYRSA_VERSION=\"(?<currentValue>\\d+\\.\\d+\\.\\d+)\""
       ],

--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,7 @@
       "customType": "regex",
       "managerFilePatterns": ["/^openvpn-install\\.sh$/"],
       "matchStrings": [
-        "EASYRSA_VERSION=\"(?<currentValue>\\d+\\.\\d+\\.\\d+)\""
+        "readonly\\s+EASYRSA_VERSION=\"(?<currentValue>\\d+\\.\\d+\\.\\d+)\""
       ],
       "depNameTemplate": "OpenVPN/easy-rsa",
       "datasourceTemplate": "github-releases",


### PR DESCRIPTION
## Summary

- Add Renovate configuration to automatically track Easy-RSA releases
- Add GitHub Action to auto-update SHA256 hash on Renovate PRs

## How it works

1. **Renovate** detects a new Easy-RSA release → creates PR updating `EASYRSA_VERSION`
2. **GitHub Action** triggers on the PR → downloads tarball → computes SHA256 → commits fix
3. PR is ready to merge with both version and hash updated

---

I intentionally updated to the second-to-last version in https://github.com/angristan/openvpn-install/commit/bda450948a933224f4f779a24a44c6279e1574a1 to test if this works.