### PR TITLE
feat: add version 10 support for RHEL-based distributions

### DIFF
--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -36,24 +36,32 @@ jobs:
             image: debian:12
           - name: centos-stream-9
             image: quay.io/centos/centos:stream9
+          - name: centos-stream-10
+            image: quay.io/centos/centos:stream10
           - name: fedora-42
             image: fedora:42
           - name: fedora-43
             image: fedora:43
           - name: rocky-8
-            image: rockylinux:8
+            image: rockylinux/rockylinux:8
           - name: rocky-9
-            image: rockylinux:9
+            image: rockylinux/rockylinux:9
+          - name: rocky-10
+            image: rockylinux/rockylinux:10
           - name: almalinux-8
             image: almalinux:8
           - name: almalinux-9
             image: almalinux:9
+          - name: almalinux-10
+            image: almalinux:10
           - name: archlinux
             image: archlinux:latest
           - name: oraclelinux-8
             image: oraclelinux:8
           - name: oraclelinux-9
             image: oraclelinux:9
+          - name: oraclelinux-10
+            image: oraclelinux:10
           - name: amazonlinux-2023
             image: amazonlinux:2023
 


### PR DESCRIPTION
## Summary

- Add version 10 support for CentOS Stream, Rocky Linux, AlmaLinux, and Oracle Linux
- Consolidate version check logic into a single check for all RHEL-based distributions
- Fix Rocky Linux Docker image names to `rockylinux/rockylinux:tag`
- Increase Easy-RSA download curl retry from 3 to 5
- Fail early if EPEL/Copr repository setup fails
- Fix Oracle Linux EPEL package name (`oracle-epel-release-el*` instead of `epel-release`)

## Changes

### `openvpn-install.sh`
- Combine version checks for CentOS/Rocky/AlmaLinux and Oracle Linux into one
- Update error message to list supported distributions
- Change Easy-RSA download `--retry 3` to `--retry 5`
- Add `|| log_fatal` to EPEL and Copr setup commands to fail early on errors
- Use `oracle-epel-release-el{8,9,10}` for Oracle Linux instead of `epel-release`

### `.github/workflows/docker-test.yml`
- Add CentOS Stream 10 (`quay.io/centos/centos:stream10`)
- Add Rocky Linux 10 (`rockylinux/rockylinux:10`)
- Add AlmaLinux 10 (`almalinux:10`)
- Add Oracle Linux 10 (`oraclelinux:10`)
- Fix Rocky Linux image names from `rockylinux:X` to `rockylinux/rockylinux:X`

## Test plan

- [ ] CI passes for existing distributions
- [ ] CI passes for new version 10 distributions (where images are available)