### PR TITLE
fix: disable ifconfig-pool-persist when duplicate-cn is enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ export PASS="1"
 - Block DNS leaks on Windows 10
 - Randomised server certificate name
 - Choice to protect clients with a password (private key encryption)
-- Option to allow multiple devices to use the same client profile simultaneously
+- Option to allow multiple devices to use the same client profile simultaneously (disables persistent IP addresses)
 - Many other little things!
 
 ## Compatibility

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -636,6 +636,7 @@ function installQuestions() {
 	done
 	log_menu ""
 	log_prompt "Do you want to allow a single .ovpn profile to be used on multiple devices simultaneously?"
+	log_prompt "Note: Enabling this disables persistent IP addresses for clients."
 	until [[ $MULTI_CLIENT =~ (y|n) ]]; do
 		read -rp "Allow multiple devices per client? [y/n]: " -e -i n MULTI_CLIENT
 	done
@@ -1124,8 +1125,12 @@ persist-key
 persist-tun
 keepalive 10 120
 topology subnet
-server 10.8.0.0 255.255.255.0
-ifconfig-pool-persist ipp.txt" >>/etc/openvpn/server.conf
+server 10.8.0.0 255.255.255.0" >>/etc/openvpn/server.conf
+
+	# ifconfig-pool-persist is incompatible with duplicate-cn
+	if [[ $MULTI_CLIENT != "y" ]]; then
+		echo "ifconfig-pool-persist ipp.txt" >>/etc/openvpn/server.conf
+	fi
 
 	# DNS resolvers
 	case $DNS in


### PR DESCRIPTION
## Summary
- Only add `ifconfig-pool-persist` to server.conf when `MULTI_CLIENT != y`
- Add note in the installation prompt about this limitation
- Update README to mention the trade-off

First reported in https://github.com/angristan/openvpn-install/issues/440#issuecomment-2987417197

## Background

`ifconfig-pool-persist` is incompatible with `duplicate-cn`. When `duplicate-cn` is enabled, OpenVPN bypasses common name matching in the IP pool allocation, making the persistence file ineffective.

From [OpenVPN source](https://github.com/OpenVPN/openvpn/blob/e5ff8247/src/openvpn/init.c#L3608-L3610):
```c
if (o->duplicate_cn && o->ifconfig_pool_persist_filename)
{
    msg(M_WARN, "WARNING: --ifconfig-pool-persist will not work with --duplicate-cn");
}
```

Previously, the script always added `ifconfig-pool-persist ipp.txt` regardless of whether `duplicate-cn` was enabled via `MULTI_CLIENT=y`.