### PR TITLE
feat: use modern data-ciphers naming while maintaining 2.4 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ The script supports the following ciphers:
 
 And defaults to `AES-128-GCM`.
 
-OpenVPN 2.4 added a feature called "NCP": _Negotiable Crypto Parameters_. It means you can provide a cipher suite like with HTTPS. It is set to `AES-256-GCM:AES-128-GCM` by default and overrides the `--cipher` parameter when used with an OpenVPN 2.4 client. For the sake of simplicity, the script set both the `--cipher` and `--ncp-cipher` to the cipher chosen above.
+OpenVPN 2.4 added a feature called "NCP": _Negotiable Crypto Parameters_. It means you can provide a cipher suite like with HTTPS. It is set to `AES-256-GCM:AES-128-GCM` by default and overrides the `--cipher` parameter when used with an OpenVPN 2.4 client. For the sake of simplicity, the script sets `--cipher` (fallback for non-NCP clients), `--data-ciphers` (modern OpenVPN 2.5+ naming), and `--ncp-ciphers` (legacy alias for OpenVPN 2.4 compatibility) to the cipher chosen above.
 
 ### Control channel
 

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -1240,6 +1240,8 @@ cert $SERVER_NAME.crt
 key $SERVER_NAME.key
 auth $HMAC_ALG
 cipher $CIPHER
+ignore-unknown-option data-ciphers
+data-ciphers $CIPHER
 ncp-ciphers $CIPHER
 tls-server
 tls-version-min 1.2
@@ -1389,6 +1391,9 @@ verify-x509-name $SERVER_NAME name
 auth $HMAC_ALG
 auth-nocache
 cipher $CIPHER
+ignore-unknown-option data-ciphers
+data-ciphers $CIPHER
+ncp-ciphers $CIPHER
 tls-client
 tls-version-min 1.2
 tls-cipher $CC_CIPHER


### PR DESCRIPTION
## Summary

- Add `data-ciphers` directive alongside `ncp-ciphers` for future-proofing
- Server config now emits both `data-ciphers` and `ncp-ciphers`
- Client config adds `ignore-unknown-option data-ciphers`, `data-ciphers`, and `ncp-ciphers` for full backward compatibility with OpenVPN 2.4 clients

## Context

The `ncp-ciphers` option is a legacy alias of `data-ciphers` that is still accepted but deprecated in OpenVPN 2.5+. This change aligns with modern naming conventions while maintaining compatibility with older 2.4 clients.