### PR TITLE
fix: improve TUN device detection to catch kernel/module mismatch

### DIFF
--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -157,6 +157,11 @@ function tunAvailable() {
 	if [ ! -e /dev/net/tun ]; then
 		return 1
 	fi
+	# Device file can exist even if kernel module isn't loaded
+	# Check if TUN actually works by trying to read from it
+	if cat /dev/net/tun 2>&1 | grep -q "No such device"; then
+		return 1
+	fi
 }
 
 function checkOS() {
@@ -238,7 +243,11 @@ function initialCheck() {
 		log_fatal "Sorry, you need to run this script as root."
 	fi
 	if ! tunAvailable; then
-		log_fatal "TUN is not available."
+		if [ ! -e /dev/net/tun ]; then
+			log_fatal "TUN is not available. /dev/net/tun does not exist."
+		else
+			log_fatal "TUN device exists but is not functional. The kernel module may not be loaded, or you may need to reboot after a kernel update."
+		fi
 	fi
 	checkOS
 }


### PR DESCRIPTION
## Summary

Improves the TUN availability check to detect when the device file exists but the kernel module isn't loaded.

### The Problem

After a kernel update (without reboot), the device file `/dev/net/tun` still exists (created by udev rules), but the TUN kernel module for the old kernel is no longer available. The script's check would pass, but OpenVPN would fail with:

```
ERROR: Cannot open TUN/TAP dev /dev/net/tun: No such device (errno=19)
```

### The Fix

The `tunAvailable()` function now also tries to read from the device. If it returns "No such device", the check fails with a helpful error message:

```
TUN device exists but is not functional. The kernel module may not be loaded, or you may need to reboot after a kernel update.
```

## Test Plan

Tested on an Arch Linux server that had this exact issue after a kernel update.