### PR TITLE
fix(arch): use pacman -S instead of -Syu to avoid system upgrades

### DIFF
--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -379,7 +379,7 @@ function installUnbound() {
 		elif [[ $OS == "opensuse" ]]; then
 			run_cmd "Installing Unbound" zypper install -y unbound
 		elif [[ $OS == "arch" ]]; then
-			run_cmd "Installing Unbound" pacman -Syu --noconfirm unbound
+			run_cmd "Installing Unbound" pacman -S --noconfirm unbound
 		fi
 	fi
 
@@ -990,7 +990,7 @@ function installOpenVPN() {
 		elif [[ $OS == 'opensuse' ]]; then
 			run_cmd "Installing OpenVPN" zypper install -y openvpn iptables openssl ca-certificates curl
 		elif [[ $OS == 'arch' ]]; then
-			run_cmd "Installing OpenVPN" pacman --needed --noconfirm -Syu openvpn iptables openssl ca-certificates curl
+			run_cmd "Installing OpenVPN" pacman -S --needed --noconfirm openvpn iptables openssl ca-certificates curl
 		fi
 
 		# Verify ChaCha20-Poly1305 compatibility if selected


### PR DESCRIPTION
## Summary
- Replace `pacman -Syu` with `pacman -S` for Arch Linux package installation

## Problem
Using `-Syu` performs a full system upgrade which can update the kernel and cause issues like TUN device failures that require a reboot before OpenVPN can start.

## Solution
Use `-S` to only install/sync the requested packages without upgrading the entire system. Users who want to upgrade their system can do so separately.

## Changes
- `pacman -Syu --noconfirm unbound` → `pacman -S --noconfirm unbound`
- `pacman --needed --noconfirm -Syu openvpn ...` → `pacman -S --needed --noconfirm openvpn ...`