### PR TITLE
fix(arch): detect pending kernel upgrades before installation

### DIFF
--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -261,7 +261,7 @@ function checkArchPendingKernelUpgrade() {
 	pending_kernels=$(pacman -Qu 2>/dev/null | grep -E '^linux(-lts|-zen|-hardened)?[[:space:]]' || true)
 
 	if [[ -n "$pending_kernels" ]]; then
-		log_error "Linux kernel upgrade(s) pending:"
+		log_warn "Linux kernel upgrade(s) pending:"
 		echo "$pending_kernels" | while read -r line; do
 			log_info "  $line"
 		done
@@ -273,7 +273,7 @@ function checkArchPendingKernelUpgrade() {
 		log_info "  sudo pacman -Syu"
 		log_info "  sudo reboot"
 		echo ""
-		log_fatal "Then run this script again."
+		log_fatal "Aborting. Please update and reboot, then run this script again."
 	fi
 
 	log_success "No pending kernel upgrades"

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -261,9 +261,9 @@ function checkArchPendingKernelUpgrade() {
 		return 0
 	fi
 
-	# Check for pending linux kernel upgrades (linux, linux-lts, linux-zen, linux-hardened)
+	# Check for pending linux kernel upgrades
 	local pending_kernels
-	pending_kernels=$(pacman -Qu 2>/dev/null | grep -E '^linux(-lts|-zen|-hardened)?[[:space:]]' || true)
+	pending_kernels=$(pacman -Qu 2>/dev/null | grep -E '^linux' || true)
 
 	if [[ -n "$pending_kernels" ]]; then
 		log_warn "Linux kernel upgrade(s) pending:"
@@ -278,7 +278,7 @@ function checkArchPendingKernelUpgrade() {
 		log_info "  sudo pacman -Syu"
 		log_info "  sudo reboot"
 		echo ""
-		log_fatal "Aborting. Please update and reboot, then run this script again."
+		log_fatal "Aborting. Run this script again after upgrading and rebooting."
 	fi
 
 	log_success "No pending kernel upgrades"


### PR DESCRIPTION
On Arch Linux, the script uses `pacman -Syu` which performs a full system upgrade. If a user's system is out of date and has pending kernel updates:

1. Script runs `pacman -Syu` to install OpenVPN
2. Kernel gets upgraded along with other packages
3. The TUN module for the **new** kernel isn't loaded (old kernel still running)
4. OpenVPN fails to start because TUN is unavailable
5. User has to reboot anyway, but now they're confused about why it broke

So we check preventively now, and ask them to upgrade & reboot before running the script

<img width="1342" height="488" alt="image" src="https://github.com/user-attachments/assets/e9646737-eaf4-4035-b247-20e8f2daea60" />