### PR TITLE
fix: use non-deprecated --genkey syntax for tls-crypt and tls-auth

### DIFF
--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -1175,11 +1175,11 @@ function installOpenVPN() {
 			;;
 		2)
 			# Generate tls-crypt key
-			run_cmd_fatal "Generating tls-crypt key" openvpn --genkey --secret /etc/openvpn/server/tls-crypt.key
+			run_cmd_fatal "Generating tls-crypt key" openvpn --genkey secret /etc/openvpn/server/tls-crypt.key
 			;;
 		3)
 			# Generate tls-auth key
-			run_cmd_fatal "Generating tls-auth key" openvpn --genkey --secret /etc/openvpn/server/tls-auth.key
+			run_cmd_fatal "Generating tls-auth key" openvpn --genkey secret /etc/openvpn/server/tls-auth.key
 			;;
 		esac
 	else


### PR DESCRIPTION
## Summary

- Replace deprecated `--genkey --secret` syntax with `--genkey secret` for tls-crypt and tls-auth key generation

The OpenVPN source explicitly warns about this:
```
WARNING: Using --genkey --secret filename is DEPRECATED. Use --genkey secret filename instead.
```

Closes #1256
Close https://github.com/angristan/openvpn-install/issues/1280