### PR TITLE
feat: support headless client revocation by name

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,28 @@ export PASS="1" # set to "2" for a password-protected client, and set PASSPHRASE
 ./openvpn-install.sh
 ```
 
+### Headless User Revocation
+
+It's also possible to automate the revocation of an existing user. The key is to provide the `MENU_OPTION` variable set to `2` along with either `CLIENT` (client name) or `CLIENTNUMBER` (1-based index from the client list).
+
+The following Bash script revokes the existing user `foo`:
+
+```bash
+#!/bin/bash
+export MENU_OPTION="2"
+export CLIENT="foo"
+./openvpn-install.sh
+```
+
+Alternatively, you can use the client number:
+
+```bash
+#!/bin/bash
+export MENU_OPTION="2"
+export CLIENTNUMBER="1"  # Revokes the first client in the list
+./openvpn-install.sh
+```
+
 ## Features
 
 - Installs and configures a ready-to-use OpenVPN server

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -1622,6 +1622,15 @@ function selectClient() {
 		log_fatal "You have no existing clients!"
 	fi
 
+	# If CLIENT is set, validate it exists as a valid client
+	if [[ -n $CLIENT ]]; then
+		if tail -n +2 /etc/openvpn/server/easy-rsa/pki/index.txt | grep "^V" | cut -d '=' -f 2 | grep -qx "$CLIENT"; then
+			return
+		else
+			log_fatal "Client '$CLIENT' not found or not valid"
+		fi
+	fi
+
 	if [[ $show_expiry == "true" ]]; then
 		local i=1
 		while read -r client; do

--- a/test/server-entrypoint.sh
+++ b/test/server-entrypoint.sh
@@ -501,19 +501,11 @@ if [ ! -f /shared/revoke-client-disconnected ]; then
 fi
 echo "Client disconnected"
 
-# Now revoke the certificate
+# Now revoke the certificate using the new CLIENT name feature
 echo "Revoking certificate for '$REVOKE_CLIENT'..."
 REVOKE_OUTPUT="/tmp/revoke-output.log"
-# MENU_OPTION=3 is revoke, CLIENTNUMBER is dynamically determined from index.txt
-# We need to find the client number for revoketest
-REVOKE_CLIENT_NUM=$(tail -n +2 /etc/openvpn/server/easy-rsa/pki/index.txt | grep "^V" | grep -n "CN=$REVOKE_CLIENT\$" | cut -d: -f1)
-if [ -z "$REVOKE_CLIENT_NUM" ]; then
-	echo "ERROR: Could not find client number for '$REVOKE_CLIENT'"
-	cat /etc/openvpn/server/easy-rsa/pki/index.txt
-	exit 1
-fi
-echo "Revoke client number: $REVOKE_CLIENT_NUM"
-(MENU_OPTION=3 CLIENTNUMBER=$REVOKE_CLIENT_NUM bash /opt/openvpn-install.sh) 2>&1 | tee "$REVOKE_OUTPUT" || true
+# MENU_OPTION=3 is revoke, CLIENT specifies the client name directly
+(MENU_OPTION=3 CLIENT=$REVOKE_CLIENT bash /opt/openvpn-install.sh) 2>&1 | tee "$REVOKE_OUTPUT" || true
 
 if grep -q "Certificate for client $REVOKE_CLIENT revoked" "$REVOKE_OUTPUT"; then
 	echo "PASS: Certificate for '$REVOKE_CLIENT' revoked successfully"


### PR DESCRIPTION
Add support for revoking clients by setting the CLIENT environment variable directly with the client name, in addition to the existing CLIENTNUMBER support (from https://github.com/angristan/openvpn-install/pull/1328)

This makes headless revocation more user-friendly as users no longer need to know the client's index number.