### PR TITLE
feat: add native nftables support

### DIFF
--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -98,6 +98,15 @@ jobs:
               name: tls-crypt-v2
               sig: "1"
               key_file: tls-crypt-v2.key
+          # Test nftables support on Debian
+          - os:
+              name: debian-12-nftables
+              image: debian:12
+              enable_nftables: true
+            tls:
+              name: tls-crypt-v2
+              sig: "1"
+              key_file: tls-crypt-v2.key
 
     name: ${{ matrix.os.name }}
     steps:
@@ -113,6 +122,7 @@ jobs:
           docker build \
             --build-arg BASE_IMAGE=${{ matrix.os.image }} \
             --build-arg ENABLE_FIREWALLD=${{ matrix.os.enable_firewalld && 'y' || 'n' }} \
+            --build-arg ENABLE_NFTABLES=${{ matrix.os.enable_nftables && 'y' || 'n' }} \
             -t openvpn-server \
             -f test/Dockerfile.server .
 

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -279,7 +279,7 @@ jobs:
       - name: Show install script log
         if: always()
         run: |
-          docker cp openvpn-server:/opt/openvpn-install.log /tmp/openvpn-install.log 2>/dev/null && \
+          docker cp openvpn-server:/root/openvpn-install.log /tmp/openvpn-install.log 2>/dev/null && \
             cat /tmp/openvpn-install.log || echo "No install log found"
 
       - name: Show client logs

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ export CLIENTNUMBER="1"  # Revokes the first client in the list
 - Installs and configures a ready-to-use OpenVPN server
 - Certificate renewal for both client and server certificates
 - Uses [official OpenVPN repositories](https://community.openvpn.net/openvpn/wiki/OpenvpnSoftwareRepos) when possible for the latest stable releases
-- Firewall rules and forwarding managed seamlessly (native firewalld support, iptables fallback)
+- Firewall rules and forwarding managed seamlessly (native firewalld and nftables support, iptables fallback)
 - If needed, the script can cleanly remove OpenVPN, including configuration and firewall rules
 - Customisable encryption settings, enhanced default settings (see [Security and Encryption](#security-and-encryption) below)
 - OpenVPN 2.4 features, mainly encryption improvements (see [Security and Encryption](#security-and-encryption) below)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
       dockerfile: test/Dockerfile.server
       args:
         BASE_IMAGE: ${BASE_IMAGE:-ubuntu:24.04}
+        ENABLE_FIREWALLD: ${ENABLE_FIREWALLD:-n}
+        ENABLE_NFTABLES: ${ENABLE_NFTABLES:-n}
     container_name: openvpn-server
     hostname: openvpn-server
     privileged: true

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -1474,11 +1474,6 @@ table ip6 openvpn-nat {
 		fi
 
 		# Add include to nftables.conf if not already present
-		# Create nftables.conf if it doesn't exist
-		if [[ ! -f /etc/nftables.conf ]]; then
-			echo '#!/usr/sbin/nft -f' > /etc/nftables.conf
-			echo 'flush ruleset' >> /etc/nftables.conf
-		fi
 		if ! grep -q 'include.*/etc/nftables/openvpn.nft' /etc/nftables.conf; then
 			run_cmd "Adding include to nftables.conf" sh -c 'echo "include \"/etc/nftables/openvpn.nft\"" >> /etc/nftables.conf'
 		fi

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -1436,8 +1436,52 @@ verb 3" >>/etc/openvpn/server/server.conf
 		fi
 
 		run_cmd "Reloading firewalld" firewall-cmd --reload
+	elif systemctl is-active --quiet nftables; then
+		# Use nftables native rules for systems with nftables active
+		log_info "nftables detected, configuring nftables rules..."
+		run_cmd_fatal "Creating nftables directory" mkdir -p /etc/nftables
+
+		# Create nftables rules file
+		echo "table inet openvpn {
+	chain input {
+		type filter hook input priority 0; policy accept;
+		iifname \"tun0\" accept
+		iifname \"$NIC\" $PROTOCOL dport $PORT accept
+	}
+
+	chain forward {
+		type filter hook forward priority 0; policy accept;
+		iifname \"$NIC\" oifname \"tun0\" accept
+		iifname \"tun0\" oifname \"$NIC\" accept
+	}
+}
+
+table ip openvpn-nat {
+	chain postrouting {
+		type nat hook postrouting priority 100; policy accept;
+		ip saddr 10.8.0.0/24 oifname \"$NIC\" masquerade
+	}
+}" >/etc/nftables/openvpn.nft
+
+		if [[ $IPV6_SUPPORT == 'y' ]]; then
+			echo "
+table ip6 openvpn-nat {
+	chain postrouting {
+		type nat hook postrouting priority 100; policy accept;
+		ip6 saddr fd42:42:42:42::/112 oifname \"$NIC\" masquerade
+	}
+}" >>/etc/nftables/openvpn.nft
+		fi
+
+		# Add include to nftables.conf if not already present
+		if ! grep -q 'include.*/etc/nftables/openvpn.nft' /etc/nftables.conf 2>/dev/null; then
+			run_cmd "Adding include to nftables.conf" sh -c 'echo "include \"/etc/nftables/openvpn.nft\"" >> /etc/nftables.conf'
+		fi
+
+		# Reload nftables to apply rules
+		run_cmd "Reloading nftables" systemctl reload nftables || nft -f /etc/nftables/openvpn.nft
 	else
-		# Use iptables for systems without firewalld
+		# Use iptables for systems without firewalld or nftables
 		run_cmd_fatal "Creating iptables directory" mkdir -p /etc/iptables
 
 		# Script to add rules
@@ -2137,6 +2181,13 @@ function removeOpenVPN() {
 			run_cmd "Removing VPN subnet rule" firewall-cmd --permanent --remove-rich-rule='rule family="ipv4" source address="10.8.0.0/24" accept' 2>/dev/null || true
 			run_cmd "Removing IPv6 source rule" firewall-cmd --permanent --remove-rich-rule='rule family="ipv6" source address="fd42:42:42:42::/112" accept' 2>/dev/null || true
 			run_cmd "Reloading firewalld" firewall-cmd --reload
+		elif [[ -f /etc/nftables/openvpn.nft ]]; then
+			# nftables was used
+			run_cmd "Removing OpenVPN nftables table" nft delete table inet openvpn
+			run_cmd "Removing OpenVPN NAT table" nft delete table ip openvpn-nat
+			nft delete table ip6 openvpn-nat 2>/dev/null || true
+			run_cmd "Removing include from nftables.conf" sed -i '/include.*openvpn\.nft/d' /etc/nftables.conf
+			run_cmd "Removing nftables rules file" rm -f /etc/nftables/openvpn.nft
 		elif [[ -f /etc/systemd/system/iptables-openvpn.service ]]; then
 			# iptables was used
 			run_cmd "Stopping iptables service" systemctl stop iptables-openvpn

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -1479,7 +1479,7 @@ table ip6 openvpn-nat {
 		fi
 
 		# Reload nftables to apply rules
-		run_cmd "Reloading nftables" systemctl reload nftables || nft -f /etc/nftables/openvpn.nft
+		run_cmd "Reloading nftables" systemctl reload nftables
 	else
 		# Use iptables for systems without firewalld or nftables
 		run_cmd_fatal "Creating iptables directory" mkdir -p /etc/iptables

--- a/test/Dockerfile.server
+++ b/test/Dockerfile.server
@@ -50,14 +50,13 @@ RUN if [ "$ENABLE_FIREWALLD" = "y" ] && command -v firewall-cmd >/dev/null; then
     fi
 
 # Enable nftables if requested (must be done after systemd is available)
-# Create default nftables.conf if it doesn't exist
+# Always overwrite nftables.conf with minimal config to avoid the default Debian
+# config (which creates filter tables) interfering with Docker networking
 RUN if [ "$ENABLE_NFTABLES" = "y" ] && command -v nft >/dev/null; then \
         systemctl enable nftables; \
         mkdir -p /etc/nftables; \
-        if [ ! -f /etc/nftables.conf ]; then \
-            echo '#!/usr/sbin/nft -f' > /etc/nftables.conf && \
-            echo 'flush ruleset' >> /etc/nftables.conf; \
-        fi; \
+        echo '#!/usr/sbin/nft -f' > /etc/nftables.conf && \
+        echo 'flush ruleset' >> /etc/nftables.conf; \
     fi
 
 # Create TUN device (will be mounted at runtime)

--- a/test/Dockerfile.server
+++ b/test/Dockerfile.server
@@ -7,38 +7,57 @@ FROM ${BASE_IMAGE}
 ARG BASE_IMAGE
 # Set to "y" to install and enable firewalld for testing
 ARG ENABLE_FIREWALLD=n
+# Set to "y" to install and enable nftables for testing
+ARG ENABLE_NFTABLES=n
 ENV DEBIAN_FRONTEND=noninteractive
 ENV ENABLE_FIREWALLD=${ENABLE_FIREWALLD}
+ENV ENABLE_NFTABLES=${ENABLE_NFTABLES}
 
 # Install basic dependencies based on the OS
 # dnsutils/bind-utils provides dig for DNS testing with Unbound
 RUN if command -v apt-get >/dev/null; then \
         apt-get update && apt-get install -y --no-install-recommends \
             iproute2 iptables curl procps systemd systemd-sysv dnsutils \
+        && if [ "$ENABLE_NFTABLES" = "y" ]; then apt-get install -y --no-install-recommends nftables; fi \
         && rm -rf /var/lib/apt/lists/*; \
     elif command -v dnf >/dev/null; then \
         dnf install -y --allowerasing \
             iproute iptables curl procps-ng systemd tar gzip bind-utils \
         && if [ "$ENABLE_FIREWALLD" = "y" ]; then dnf install -y firewalld; fi \
+        && if [ "$ENABLE_NFTABLES" = "y" ]; then dnf install -y nftables; fi \
         && dnf clean all; \
     elif command -v yum >/dev/null; then \
         yum install -y \
             iproute iptables curl procps-ng systemd tar gzip bind-utils \
         && if [ "$ENABLE_FIREWALLD" = "y" ]; then yum install -y firewalld; fi \
+        && if [ "$ENABLE_NFTABLES" = "y" ]; then yum install -y nftables; fi \
         && yum clean all; \
     elif command -v pacman >/dev/null; then \
         pacman -Syu --noconfirm \
             iproute2 iptables curl procps-ng bind \
+        && if [ "$ENABLE_NFTABLES" = "y" ]; then pacman -S --noconfirm nftables; fi \
         && pacman -Scc --noconfirm; \
     elif command -v zypper >/dev/null; then \
         zypper install -y \
             iproute2 iptables curl procps systemd tar gzip bind-utils gawk \
+        && if [ "$ENABLE_NFTABLES" = "y" ]; then zypper install -y nftables; fi \
         && zypper clean -a; \
     fi
 
 # Enable firewalld if requested (must be done after systemd is available)
 RUN if [ "$ENABLE_FIREWALLD" = "y" ] && command -v firewall-cmd >/dev/null; then \
         systemctl enable firewalld; \
+    fi
+
+# Enable nftables if requested (must be done after systemd is available)
+# Create default nftables.conf if it doesn't exist
+RUN if [ "$ENABLE_NFTABLES" = "y" ] && command -v nft >/dev/null; then \
+        systemctl enable nftables; \
+        mkdir -p /etc/nftables; \
+        if [ ! -f /etc/nftables.conf ]; then \
+            echo '#!/usr/sbin/nft -f' > /etc/nftables.conf && \
+            echo 'flush ruleset' >> /etc/nftables.conf; \
+        fi; \
     fi
 
 # Create TUN device (will be mounted at runtime)

--- a/test/Dockerfile.server
+++ b/test/Dockerfile.server
@@ -50,13 +50,11 @@ RUN if [ "$ENABLE_FIREWALLD" = "y" ] && command -v firewall-cmd >/dev/null; then
     fi
 
 # Enable nftables if requested (must be done after systemd is available)
-# Always overwrite nftables.conf with minimal config to avoid the default Debian
-# config (which creates filter tables) interfering with Docker networking
+# Use empty nftables.conf - do NOT flush ruleset as it removes Docker's networking rules
 RUN if [ "$ENABLE_NFTABLES" = "y" ] && command -v nft >/dev/null; then \
         systemctl enable nftables; \
         mkdir -p /etc/nftables; \
-        echo '#!/usr/sbin/nft -f' > /etc/nftables.conf && \
-        echo 'flush ruleset' >> /etc/nftables.conf; \
+        echo '#!/usr/sbin/nft -f' > /etc/nftables.conf; \
     fi
 
 # Create TUN device (will be mounted at runtime)


### PR DESCRIPTION
- Add nftables as a third firewall backend option alongside firewalld and iptables
- Detection priority: firewalld → nftables → iptables (legacy fallback)
- Uses dedicated `openvpn` and `openvpn-nat` tables for clean isolation
- Integrates with native `nftables.service` via include in `/etc/nftables.conf`


Closes https://github.com/angristan/openvpn-install/issues/530