### PR TITLE
fix: use /etc/openvpn/server/ for tls-crypt-v2 temp files

### DIFF
--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -30,6 +30,8 @@ jobs:
             image: ubuntu:22.04
           - name: ubuntu-24.04
             image: ubuntu:24.04
+          - name: ubuntu-25.10
+            image: ubuntu:25.10
           - name: debian-11
             image: debian:11
           - name: debian-12


### PR DESCRIPTION
## Summary

- Fix tls-crypt-v2 client key generation failing on Ubuntu 25.04+ with "Permission denied"
- Add Ubuntu 25.10 to CI test matrix

## Root Cause

Ubuntu 25.04 introduced an AppArmor profile for openvpn (`/etc/apparmor.d/openvpn`) that restricts where the binary can write. The allowed paths are:
- `/etc/openvpn/{,**}`
- `@{HOME}/**` (owner only)

The script was using `mktemp` which creates files in `/tmp`, causing the error:
```
Cannot open file '/tmp/tmp.XXX' for write: Permission denied (errno=13)
```

## Fix

Changed the temp file location from `/tmp` to `/etc/openvpn/server/`:
```bash
# Before
tls_crypt_v2_tmpfile=$(mktemp)

# After
tls_crypt_v2_tmpfile=$(mktemp /etc/openvpn/server/tls-crypt-v2-client.XXXXXX)
```

Fixes #1391