### PR TITLE
feat: add option to list connected clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ When OpenVPN is installed, you can run the script again, and you will get the ch
 - Revoke a client
 - Renew certificates (client or server)
 - Uninstall OpenVPN
+- List connected clients (shows real-time connection status)
 
 In your home directory, you will have `.ovpn` files. These are the client configuration files. Download them from your server and connect using your favorite OpenVPN client.
 


### PR DESCRIPTION
## Summary
- Add new menu option "3) List connected clients" to show currently connected VPN clients
- Parses `/var/log/openvpn/status.log` and displays client name, real IP, VPN IP, connection time, and transfer stats
- Human-readable byte formatting (K/M/G)

## Example output
```
   Name                 Real Address           VPN IP           Connected Since      Transfer
   ----                 ------------           ------           ---------------      --------
   stan                 123.45.211.11:28291    10.8.0.2         2025-12-14 10:13:22  ↓7.3M ↑123.5M
```

Closes https://github.com/angristan/openvpn-install/pull/863