### PR TITLE
feat: flexible IPv4/IPv6 support with independent endpoint and client addressing

### DIFF
--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -109,6 +109,15 @@ jobs:
               name: tls-crypt-v2
               sig: crypt-v2
               key_file: tls-crypt-v2.key
+          # Test IPv6 dual-stack support on Ubuntu
+          - os:
+              name: ubuntu-24.04-dual-stack
+              image: ubuntu:24.04
+              client_ipv6: true
+            tls:
+              name: tls-crypt-v2
+              sig: crypt-v2
+              key_file: tls-crypt-v2.key
 
     name: ${{ matrix.os.name }}
     steps:
@@ -146,6 +155,7 @@ jobs:
             --cgroupns=host \
             --device=/dev/net/tun:/dev/net/tun \
             --sysctl net.ipv4.ip_forward=1 \
+            --sysctl net.ipv6.conf.all.forwarding=1 \
             --network vpn-test \
             --ip 172.28.0.10 \
             -v shared-config:/shared \
@@ -155,6 +165,7 @@ jobs:
             --stop-signal SIGRTMIN+3 \
             -e TLS_SIG=${{ matrix.tls.sig }} \
             -e TLS_KEY_FILE=${{ matrix.tls.key_file }} \
+            -e CLIENT_IPV6=${{ matrix.os.client_ipv6 && 'y' || 'n' }} \
             openvpn-server
 
       - name: Wait for server installation and startup

--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ That said, OpenVPN still makes sense when you need:
 - Flexible IPv4/IPv6 support:
   - IPv4 or IPv6 server endpoint (how clients connect)
   - IPv4-only, IPv6-only, or dual-stack clients (VPN addressing and internet access)
-  - All combinations supported: 4→4, 4→4/6, 6→4, 6→6, 6→4/6
+  - All combinations supported: 4→4, 4→4/6, 4→6, 6→4, 6→6, 6→4/6
+  - Automatic leak prevention: blocks undesired protocol in single-stack modes
 - Unprivileged mode: run as `nobody`/`nogroup`
 - Block DNS leaks on Windows 10
 - Randomised server certificate name

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ That said, OpenVPN still makes sense when you need:
 - List and monitor connected clients
 - Uses [official OpenVPN repositories](https://community.openvpn.net/openvpn/wiki/OpenvpnSoftwareRepos) when possible for the latest stable releases
 - Firewall rules and forwarding managed seamlessly (native firewalld and nftables support, iptables fallback)
-- Configurable VPN subnet (default: `10.8.0.0/24`)
+- Configurable VPN subnets (IPv4: default `10.8.0.0/24`, IPv6: default `fd42:42:42:42::/112`)
 - Configurable tunnel MTU (default: `1500`)
 - If needed, the script can cleanly remove OpenVPN, including configuration and firewall rules
 - Customisable encryption settings, enhanced default settings (see [Security and Encryption](#security-and-encryption) below)
@@ -51,7 +51,10 @@ That said, OpenVPN still makes sense when you need:
 - Variety of DNS resolvers to be pushed to the clients
 - Choice to use a self-hosted resolver with Unbound (supports already existing Unbound installations)
 - Choice between TCP and UDP
-- NATed IPv6 support
+- Flexible IPv4/IPv6 support:
+  - IPv4 or IPv6 server endpoint (how clients connect)
+  - IPv4-only, IPv6-only, or dual-stack clients (VPN addressing and internet access)
+  - All combinations supported: 4→4, 4→4/6, 6→4, 6→6, 6→4/6
 - Unprivileged mode: run as `nobody`/`nogroup`
 - Block DNS leaks on Windows 10
 - Randomised server certificate name
@@ -249,7 +252,19 @@ The `install` command supports many options for customization:
 ./openvpn-install.sh install --cipher AES-256-GCM --cert-type rsa --rsa-bits 4096
 
 # Custom VPN subnet
-./openvpn-install.sh install --subnet 10.9.0.0
+./openvpn-install.sh install --subnet-ipv4 10.9.0.0
+
+# Enable dual-stack (IPv4 + IPv6) for clients
+./openvpn-install.sh install --client-ipv4 --client-ipv6
+
+# IPv6-only clients (no IPv4)
+./openvpn-install.sh install --no-client-ipv4 --client-ipv6
+
+# IPv6 endpoint (server listens on IPv6, clients connect via IPv6)
+./openvpn-install.sh install --endpoint-type 6 --endpoint 2001:db8::1
+
+# Custom IPv6 subnet for dual-stack setup
+./openvpn-install.sh install --client-ipv6 --subnet-ipv6 fd00:1234:5678::
 
 # Skip initial client creation
 ./openvpn-install.sh install --no-client
@@ -267,9 +282,14 @@ The `install` command supports many options for customization:
 **Network Options:**
 
 - `--endpoint <host>` - Public IP or hostname for clients (default: auto-detected)
+- `--endpoint-type <4|6>` - Endpoint IP version (default: `4`)
 - `--ip <addr>` - Server listening IP (default: auto-detected)
-- `--ipv6` - Enable IPv6 support (default: disabled)
-- `--subnet <x.x.x.0>` - VPN subnet (default: `10.8.0.0`)
+- `--client-ipv4` - Enable IPv4 for VPN clients (default: enabled)
+- `--no-client-ipv4` - Disable IPv4 for VPN clients
+- `--client-ipv6` - Enable IPv6 for VPN clients (default: disabled)
+- `--no-client-ipv6` - Disable IPv6 for VPN clients
+- `--subnet-ipv4 <x.x.x.0>` - IPv4 VPN subnet (default: `10.8.0.0`)
+- `--subnet-ipv6 <prefix>` - IPv6 VPN subnet (default: `fd42:42:42:42::`)
 - `--port <num>` - OpenVPN port (default: `1194`)
 - `--port-random` - Use random port (49152-65535)
 - `--protocol <udp|tcp>` - Protocol (default: `udp`)

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -834,16 +834,14 @@ cmd_install() {
 		# Set legacy IPV6_SUPPORT for compatibility
 		IPV6_SUPPORT="$CLIENT_IPV6"
 
-		# IPv4 Subnet
-		if [[ $CLIENT_IPV4 == "y" ]]; then
-			if [[ -n $VPN_SUBNET_IPV4 ]]; then
-				SUBNET_IPV4_CHOICE=${SUBNET_IPV4_CHOICE:-2}
-			else
-				SUBNET_IPV4_CHOICE=${SUBNET_IPV4_CHOICE:-1}
-				VPN_SUBNET_IPV4="10.8.0.0"
-			fi
-			VPN_GATEWAY_IPV4="${VPN_SUBNET_IPV4%.*}.1"
+		# IPv4 Subnet - always needed for leak prevention (redirect-gateway def1)
+		if [[ -n $VPN_SUBNET_IPV4 ]]; then
+			SUBNET_IPV4_CHOICE=${SUBNET_IPV4_CHOICE:-2}
+		else
+			SUBNET_IPV4_CHOICE=${SUBNET_IPV4_CHOICE:-1}
+			VPN_SUBNET_IPV4="10.8.0.0"
 		fi
+		VPN_GATEWAY_IPV4="${VPN_SUBNET_IPV4%.*}.1"
 
 		# IPv6 Subnet
 		if [[ $CLIENT_IPV6 == "y" ]]; then
@@ -1934,7 +1932,7 @@ function installQuestions() {
 	esac
 
 	# ==========================================================================
-	# Step 5: IPv4 subnet (if IPv4 enabled for clients)
+	# Step 5: IPv4 subnet (prompt only if IPv4 enabled, but always set for leak prevention)
 	# ==========================================================================
 	if [[ $CLIENT_IPV4 == "y" ]]; then
 		log_menu ""
@@ -1957,9 +1955,12 @@ function installQuestions() {
 			fi
 			;;
 		esac
-		# Calculate gateway (first usable IP in the subnet)
-		VPN_GATEWAY_IPV4="${VPN_SUBNET_IPV4%.*}.1"
+	else
+		# IPv6-only mode: still need IPv4 subnet for leak prevention (redirect-gateway def1)
+		VPN_SUBNET_IPV4="10.8.0.0"
 	fi
+	# Calculate gateway (first usable IP in the subnet)
+	VPN_GATEWAY_IPV4="${VPN_SUBNET_IPV4%.*}.1"
 
 	# ==========================================================================
 	# Step 6: IPv6 subnet (if IPv6 enabled for clients)
@@ -2372,16 +2373,14 @@ function installOpenVPN() {
 		fi
 		IPV6_SUPPORT="$CLIENT_IPV6"
 
-		# IPv4 subnet defaults
-		if [[ $CLIENT_IPV4 == "y" ]]; then
-			if [[ -n $VPN_SUBNET_IPV4 ]]; then
-				SUBNET_IPV4_CHOICE=${SUBNET_IPV4_CHOICE:-2}
-			else
-				SUBNET_IPV4_CHOICE=${SUBNET_IPV4_CHOICE:-1}
-				VPN_SUBNET_IPV4="10.8.0.0"
-			fi
-			VPN_GATEWAY_IPV4="${VPN_SUBNET_IPV4%.*}.1"
+		# IPv4 subnet defaults - always needed for leak prevention
+		if [[ -n $VPN_SUBNET_IPV4 ]]; then
+			SUBNET_IPV4_CHOICE=${SUBNET_IPV4_CHOICE:-2}
+		else
+			SUBNET_IPV4_CHOICE=${SUBNET_IPV4_CHOICE:-1}
+			VPN_SUBNET_IPV4="10.8.0.0"
 		fi
+		VPN_GATEWAY_IPV4="${VPN_SUBNET_IPV4%.*}.1"
 
 		# IPv6 subnet defaults
 		if [[ $CLIENT_IPV6 == "y" ]]; then

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -2630,10 +2630,9 @@ persist-tun
 keepalive 10 120
 topology subnet" >>/etc/openvpn/server/server.conf
 
-	# IPv4 server directive (only if clients get IPv4)
-	if [[ $CLIENT_IPV4 == "y" ]]; then
-		echo "server $VPN_SUBNET_IPV4 255.255.255.0" >>/etc/openvpn/server/server.conf
-	fi
+	# IPv4 server directive - always assign IPv4 to clients for proper routing
+	# Even for IPv6-only mode, we need IPv4 addresses so redirect-gateway def1 can block IPv4 leaks
+	echo "server $VPN_SUBNET_IPV4 255.255.255.0" >>/etc/openvpn/server/server.conf
 
 	# IPv6 server directive (only if clients get IPv6)
 	if [[ $CLIENT_IPV6 == "y" ]]; then
@@ -2678,44 +2677,104 @@ topology subnet" >>/etc/openvpn/server/server.conf
 		fi
 		;;
 	3) # Cloudflare
-		echo 'push "dhcp-option DNS 1.0.0.1"' >>/etc/openvpn/server/server.conf
-		echo 'push "dhcp-option DNS 1.1.1.1"' >>/etc/openvpn/server/server.conf
+		if [[ $CLIENT_IPV4 == 'y' ]]; then
+			echo 'push "dhcp-option DNS 1.0.0.1"' >>/etc/openvpn/server/server.conf
+			echo 'push "dhcp-option DNS 1.1.1.1"' >>/etc/openvpn/server/server.conf
+		fi
+		if [[ $CLIENT_IPV6 == 'y' ]]; then
+			echo 'push "dhcp-option DNS 2606:4700:4700::1001"' >>/etc/openvpn/server/server.conf
+			echo 'push "dhcp-option DNS 2606:4700:4700::1111"' >>/etc/openvpn/server/server.conf
+		fi
 		;;
 	4) # Quad9
-		echo 'push "dhcp-option DNS 9.9.9.9"' >>/etc/openvpn/server/server.conf
-		echo 'push "dhcp-option DNS 149.112.112.112"' >>/etc/openvpn/server/server.conf
+		if [[ $CLIENT_IPV4 == 'y' ]]; then
+			echo 'push "dhcp-option DNS 9.9.9.9"' >>/etc/openvpn/server/server.conf
+			echo 'push "dhcp-option DNS 149.112.112.112"' >>/etc/openvpn/server/server.conf
+		fi
+		if [[ $CLIENT_IPV6 == 'y' ]]; then
+			echo 'push "dhcp-option DNS 2620:fe::fe"' >>/etc/openvpn/server/server.conf
+			echo 'push "dhcp-option DNS 2620:fe::9"' >>/etc/openvpn/server/server.conf
+		fi
 		;;
 	5) # Quad9 uncensored
-		echo 'push "dhcp-option DNS 9.9.9.10"' >>/etc/openvpn/server/server.conf
-		echo 'push "dhcp-option DNS 149.112.112.10"' >>/etc/openvpn/server/server.conf
+		if [[ $CLIENT_IPV4 == 'y' ]]; then
+			echo 'push "dhcp-option DNS 9.9.9.10"' >>/etc/openvpn/server/server.conf
+			echo 'push "dhcp-option DNS 149.112.112.10"' >>/etc/openvpn/server/server.conf
+		fi
+		if [[ $CLIENT_IPV6 == 'y' ]]; then
+			echo 'push "dhcp-option DNS 2620:fe::10"' >>/etc/openvpn/server/server.conf
+			echo 'push "dhcp-option DNS 2620:fe::fe:10"' >>/etc/openvpn/server/server.conf
+		fi
 		;;
 	6) # FDN
-		echo 'push "dhcp-option DNS 80.67.169.40"' >>/etc/openvpn/server/server.conf
-		echo 'push "dhcp-option DNS 80.67.169.12"' >>/etc/openvpn/server/server.conf
+		if [[ $CLIENT_IPV4 == 'y' ]]; then
+			echo 'push "dhcp-option DNS 80.67.169.40"' >>/etc/openvpn/server/server.conf
+			echo 'push "dhcp-option DNS 80.67.169.12"' >>/etc/openvpn/server/server.conf
+		fi
+		if [[ $CLIENT_IPV6 == 'y' ]]; then
+			echo 'push "dhcp-option DNS 2001:910:800::40"' >>/etc/openvpn/server/server.conf
+			echo 'push "dhcp-option DNS 2001:910:800::12"' >>/etc/openvpn/server/server.conf
+		fi
 		;;
 	7) # DNS.WATCH
-		echo 'push "dhcp-option DNS 84.200.69.80"' >>/etc/openvpn/server/server.conf
-		echo 'push "dhcp-option DNS 84.200.70.40"' >>/etc/openvpn/server/server.conf
+		if [[ $CLIENT_IPV4 == 'y' ]]; then
+			echo 'push "dhcp-option DNS 84.200.69.80"' >>/etc/openvpn/server/server.conf
+			echo 'push "dhcp-option DNS 84.200.70.40"' >>/etc/openvpn/server/server.conf
+		fi
+		if [[ $CLIENT_IPV6 == 'y' ]]; then
+			echo 'push "dhcp-option DNS 2001:1608:10:25::1c04:b12f"' >>/etc/openvpn/server/server.conf
+			echo 'push "dhcp-option DNS 2001:1608:10:25::9249:d69b"' >>/etc/openvpn/server/server.conf
+		fi
 		;;
 	8) # OpenDNS
-		echo 'push "dhcp-option DNS 208.67.222.222"' >>/etc/openvpn/server/server.conf
-		echo 'push "dhcp-option DNS 208.67.220.220"' >>/etc/openvpn/server/server.conf
+		if [[ $CLIENT_IPV4 == 'y' ]]; then
+			echo 'push "dhcp-option DNS 208.67.222.222"' >>/etc/openvpn/server/server.conf
+			echo 'push "dhcp-option DNS 208.67.220.220"' >>/etc/openvpn/server/server.conf
+		fi
+		if [[ $CLIENT_IPV6 == 'y' ]]; then
+			echo 'push "dhcp-option DNS 2620:119:35::35"' >>/etc/openvpn/server/server.conf
+			echo 'push "dhcp-option DNS 2620:119:53::53"' >>/etc/openvpn/server/server.conf
+		fi
 		;;
 	9) # Google
-		echo 'push "dhcp-option DNS 8.8.8.8"' >>/etc/openvpn/server/server.conf
-		echo 'push "dhcp-option DNS 8.8.4.4"' >>/etc/openvpn/server/server.conf
+		if [[ $CLIENT_IPV4 == 'y' ]]; then
+			echo 'push "dhcp-option DNS 8.8.8.8"' >>/etc/openvpn/server/server.conf
+			echo 'push "dhcp-option DNS 8.8.4.4"' >>/etc/openvpn/server/server.conf
+		fi
+		if [[ $CLIENT_IPV6 == 'y' ]]; then
+			echo 'push "dhcp-option DNS 2001:4860:4860::8888"' >>/etc/openvpn/server/server.conf
+			echo 'push "dhcp-option DNS 2001:4860:4860::8844"' >>/etc/openvpn/server/server.conf
+		fi
 		;;
 	10) # Yandex Basic
-		echo 'push "dhcp-option DNS 77.88.8.8"' >>/etc/openvpn/server/server.conf
-		echo 'push "dhcp-option DNS 77.88.8.1"' >>/etc/openvpn/server/server.conf
+		if [[ $CLIENT_IPV4 == 'y' ]]; then
+			echo 'push "dhcp-option DNS 77.88.8.8"' >>/etc/openvpn/server/server.conf
+			echo 'push "dhcp-option DNS 77.88.8.1"' >>/etc/openvpn/server/server.conf
+		fi
+		if [[ $CLIENT_IPV6 == 'y' ]]; then
+			echo 'push "dhcp-option DNS 2a02:6b8::feed:0ff"' >>/etc/openvpn/server/server.conf
+			echo 'push "dhcp-option DNS 2a02:6b8:0:1::feed:0ff"' >>/etc/openvpn/server/server.conf
+		fi
 		;;
 	11) # AdGuard DNS
-		echo 'push "dhcp-option DNS 94.140.14.14"' >>/etc/openvpn/server/server.conf
-		echo 'push "dhcp-option DNS 94.140.15.15"' >>/etc/openvpn/server/server.conf
+		if [[ $CLIENT_IPV4 == 'y' ]]; then
+			echo 'push "dhcp-option DNS 94.140.14.14"' >>/etc/openvpn/server/server.conf
+			echo 'push "dhcp-option DNS 94.140.15.15"' >>/etc/openvpn/server/server.conf
+		fi
+		if [[ $CLIENT_IPV6 == 'y' ]]; then
+			echo 'push "dhcp-option DNS 2a10:50c0::ad1:ff"' >>/etc/openvpn/server/server.conf
+			echo 'push "dhcp-option DNS 2a10:50c0::ad2:ff"' >>/etc/openvpn/server/server.conf
+		fi
 		;;
 	12) # NextDNS
-		echo 'push "dhcp-option DNS 45.90.28.167"' >>/etc/openvpn/server/server.conf
-		echo 'push "dhcp-option DNS 45.90.30.167"' >>/etc/openvpn/server/server.conf
+		if [[ $CLIENT_IPV4 == 'y' ]]; then
+			echo 'push "dhcp-option DNS 45.90.28.167"' >>/etc/openvpn/server/server.conf
+			echo 'push "dhcp-option DNS 45.90.30.167"' >>/etc/openvpn/server/server.conf
+		fi
+		if [[ $CLIENT_IPV6 == 'y' ]]; then
+			echo 'push "dhcp-option DNS 2a07:a8c0::"' >>/etc/openvpn/server/server.conf
+			echo 'push "dhcp-option DNS 2a07:a8c1::"' >>/etc/openvpn/server/server.conf
+		fi
 		;;
 	13) # Custom DNS
 		echo "push \"dhcp-option DNS $DNS1\"" >>/etc/openvpn/server/server.conf
@@ -2725,13 +2784,16 @@ topology subnet" >>/etc/openvpn/server/server.conf
 		;;
 	esac
 
-	# Redirect gateway settings based on client IP versions
-	if [[ $CLIENT_IPV4 == "y" ]]; then
-		echo 'push "redirect-gateway def1 bypass-dhcp"' >>/etc/openvpn/server/server.conf
-	fi
+	# Redirect gateway settings - always redirect both IPv4 and IPv6 to prevent leaks
+	# For IPv4: redirect-gateway def1 routes all IPv4 through VPN (or drops it if IPv4 not configured)
+	# For IPv6: route-ipv6 + redirect-gateway ipv6 routes all IPv6, or block-ipv6 drops it
+	echo 'push "redirect-gateway def1 bypass-dhcp"' >>/etc/openvpn/server/server.conf
 	if [[ $CLIENT_IPV6 == "y" ]]; then
 		echo 'push "route-ipv6 2000::/3"' >>/etc/openvpn/server/server.conf
 		echo 'push "redirect-gateway ipv6"' >>/etc/openvpn/server/server.conf
+	else
+		# Block IPv6 on clients to prevent IPv6 leaks when VPN only handles IPv4
+		echo 'push "block-ipv6"' >>/etc/openvpn/server/server.conf
 	fi
 
 	if [[ -n $MTU ]]; then

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -510,10 +510,10 @@ validate_subnet_ipv6() {
 	# We expect formats like: fd42:42:42:42:: or fdxx:xxxx:xxxx:xxxx::
 	# The script will append /112 for the server directive
 
-	# Basic IPv6 ULA validation (fd00::/8 range)
-	# ULA format: fdxx:xxxx:xxxx:xxxx:: where x is hex
-	if ! [[ "$subnet" =~ ^fd[0-9a-fA-F]{0,2}(:[0-9a-fA-F]{0,4}){0,6}::$ ]]; then
-		log_fatal "Invalid IPv6 subnet: $subnet. Must be a ULA address ending with :: (e.g., fd42:42:42:42::)"
+	# IPv6 ULA validation (fd00::/8 range with at least /48 prefix)
+	# ULA format: fdxx:xxxx:xxxx:: or fdxx:xxxx:xxxx:xxxx:: where x is hex
+	if ! [[ "$subnet" =~ ^fd[0-9a-fA-F]{2}(:[0-9a-fA-F]{1,4}){2,5}::$ ]]; then
+		log_fatal "Invalid IPv6 subnet: $subnet. Must be a ULA address with at least a /48 prefix, ending with :: (e.g., fd42:42:42::)"
 	fi
 }
 
@@ -825,6 +825,11 @@ cmd_install() {
 		# Client IP versions
 		CLIENT_IPV4=${CLIENT_IPV4:-y}
 		CLIENT_IPV6=${CLIENT_IPV6:-n}
+
+		# Validate at least one IP version is enabled
+		if [[ $CLIENT_IPV4 != "y" ]] && [[ $CLIENT_IPV6 != "y" ]]; then
+			log_fatal "At least one of --client-ipv4 or --client-ipv6 must be enabled"
+		fi
 
 		# Set legacy IPV6_SUPPORT for compatibility
 		IPV6_SUPPORT="$CLIENT_IPV6"

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -2618,9 +2618,11 @@ topology subnet" >>/etc/openvpn/server/server.conf
 
 	# IPv6 server directive (only if clients get IPv6)
 	if [[ $CLIENT_IPV6 == "y" ]]; then
-		echo "server-ipv6 ${VPN_SUBNET_IPV6}/112" >>/etc/openvpn/server/server.conf
-		echo "tun-ipv6" >>/etc/openvpn/server/server.conf
-		echo "push tun-ipv6" >>/etc/openvpn/server/server.conf
+		{
+			echo "server-ipv6 ${VPN_SUBNET_IPV6}/112"
+			echo "tun-ipv6"
+			echo "push tun-ipv6"
+		} >>/etc/openvpn/server/server.conf
 	fi
 
 	# ifconfig-pool-persist is incompatible with duplicate-cn

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -2352,10 +2352,24 @@ function installOpenVPN() {
 
 		# Endpoint type defaults
 		ENDPOINT_TYPE=${ENDPOINT_TYPE:-4}
+		# Set ENDPOINT_TYPE_CHOICE for installQuestions (1=IPv4, 2=IPv6)
+		if [[ $ENDPOINT_TYPE == "6" ]]; then
+			ENDPOINT_TYPE_CHOICE=${ENDPOINT_TYPE_CHOICE:-2}
+		else
+			ENDPOINT_TYPE_CHOICE=${ENDPOINT_TYPE_CHOICE:-1}
+		fi
 
 		# Client IP version defaults
 		CLIENT_IPV4=${CLIENT_IPV4:-y}
 		CLIENT_IPV6=${CLIENT_IPV6:-n}
+		# Set CLIENT_IP_CHOICE for installQuestions (1=IPv4 only, 2=IPv6 only, 3=Both)
+		if [[ $CLIENT_IPV4 == "y" ]] && [[ $CLIENT_IPV6 == "y" ]]; then
+			CLIENT_IP_CHOICE=${CLIENT_IP_CHOICE:-3}
+		elif [[ $CLIENT_IPV6 == "y" ]]; then
+			CLIENT_IP_CHOICE=${CLIENT_IP_CHOICE:-2}
+		else
+			CLIENT_IP_CHOICE=${CLIENT_IP_CHOICE:-1}
+		fi
 		IPV6_SUPPORT="$CLIENT_IPV6"
 
 		# IPv4 subnet defaults

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -821,10 +821,24 @@ cmd_install() {
 
 		# Endpoint type (default: IPv4)
 		ENDPOINT_TYPE=${ENDPOINT_TYPE:-4}
+		# Set ENDPOINT_TYPE_CHOICE for installQuestions (1=IPv4, 2=IPv6)
+		if [[ $ENDPOINT_TYPE == "6" ]]; then
+			ENDPOINT_TYPE_CHOICE=${ENDPOINT_TYPE_CHOICE:-2}
+		else
+			ENDPOINT_TYPE_CHOICE=${ENDPOINT_TYPE_CHOICE:-1}
+		fi
 
 		# Client IP versions
 		CLIENT_IPV4=${CLIENT_IPV4:-y}
 		CLIENT_IPV6=${CLIENT_IPV6:-n}
+		# Set CLIENT_IP_CHOICE for installQuestions (1=IPv4 only, 2=IPv6 only, 3=Both)
+		if [[ $CLIENT_IPV4 == "y" ]] && [[ $CLIENT_IPV6 == "y" ]]; then
+			CLIENT_IP_CHOICE=${CLIENT_IP_CHOICE:-3}
+		elif [[ $CLIENT_IPV6 == "y" ]]; then
+			CLIENT_IP_CHOICE=${CLIENT_IP_CHOICE:-2}
+		else
+			CLIENT_IP_CHOICE=${CLIENT_IP_CHOICE:-1}
+		fi
 
 		# Validate at least one IP version is enabled
 		if [[ $CLIENT_IPV4 != "y" ]] && [[ $CLIENT_IPV6 != "y" ]]; then

--- a/test/client-entrypoint.sh
+++ b/test/client-entrypoint.sh
@@ -26,11 +26,15 @@ cat /shared/client.ovpn
 if [ -f /shared/vpn-config.env ]; then
 	# shellcheck source=/dev/null
 	source /shared/vpn-config.env
-	echo "VPN config loaded: VPN_SUBNET=$VPN_SUBNET, VPN_GATEWAY=$VPN_GATEWAY"
+	echo "VPN config loaded: VPN_SUBNET_IPV4=$VPN_SUBNET_IPV4, VPN_GATEWAY=$VPN_GATEWAY"
+	if [ "${CLIENT_IPV6:-n}" = "y" ]; then
+		echo "IPv6 enabled: VPN_SUBNET_IPV6=$VPN_SUBNET_IPV6, VPN_GATEWAY_IPV6=$VPN_GATEWAY_IPV6"
+	fi
 else
 	echo "WARNING: vpn-config.env not found, using defaults"
-	VPN_SUBNET="10.8.0.0"
+	VPN_SUBNET_IPV4="10.8.0.0"
 	VPN_GATEWAY="10.8.0.1"
+	CLIENT_IPV6="n"
 fi
 
 # Connect to VPN
@@ -60,24 +64,49 @@ sleep 5
 echo ""
 echo "=== Running connectivity tests ==="
 
-# Test 1: Check tun0 interface
-echo "Test 1: Checking tun0 interface..."
+# Test 1: Check tun0 interface (IPv4)
+echo "Test 1: Checking tun0 interface (IPv4)..."
 # Extract base of subnet (e.g., "10.9.0" from "10.9.0.0")
-VPN_SUBNET_BASE="${VPN_SUBNET%.*}"
+VPN_SUBNET_BASE="${VPN_SUBNET_IPV4%.*}"
 if ip addr show tun0 | grep -q "$VPN_SUBNET_BASE"; then
-	echo "PASS: tun0 interface has correct IP range (${VPN_SUBNET_BASE}.x)"
+	echo "PASS: tun0 interface has correct IPv4 range (${VPN_SUBNET_BASE}.x)"
 else
-	echo "FAIL: tun0 interface doesn't have expected IP"
+	echo "FAIL: tun0 interface doesn't have expected IPv4"
 	exit 1
 fi
 
-# Test 2: Ping VPN gateway (retries indefinitely, relies on job timeout)
-echo "Test 2: Pinging VPN gateway ($VPN_GATEWAY)..."
+# Test 1b: Check tun0 IPv6 address (if IPv6 enabled)
+if [ "${CLIENT_IPV6:-n}" = "y" ]; then
+	echo "Test 1b: Checking tun0 interface (IPv6)..."
+	# Extract prefix of subnet (e.g., "fd42:42:42:42" from "fd42:42:42:42::")
+	VPN_SUBNET_IPV6_PREFIX="${VPN_SUBNET_IPV6%::}"
+	if ip -6 addr show tun0 | grep -q "$VPN_SUBNET_IPV6_PREFIX"; then
+		echo "PASS: tun0 interface has correct IPv6 range (${VPN_SUBNET_IPV6_PREFIX}::x)"
+	else
+		echo "FAIL: tun0 interface doesn't have expected IPv6"
+		ip -6 addr show tun0
+		exit 1
+	fi
+fi
+
+# Test 2: Ping VPN gateway (IPv4) (retries indefinitely, relies on job timeout)
+echo "Test 2: Pinging VPN gateway (IPv4) ($VPN_GATEWAY)..."
 while ! ping -c 3 -W 2 "$VPN_GATEWAY" >/dev/null 2>&1; do
 	echo "Ping failed, retrying..."
 	sleep 3
 done
-echo "PASS: Can ping VPN gateway"
+echo "PASS: Can ping VPN gateway (IPv4)"
+
+# Test 2b: Ping VPN gateway (IPv6, if enabled)
+if [ "${CLIENT_IPV6:-n}" = "y" ]; then
+	echo "Test 2b: Pinging VPN gateway (IPv6) ($VPN_GATEWAY_IPV6)..."
+	if ping6 -c 5 "$VPN_GATEWAY_IPV6"; then
+		echo "PASS: Can ping VPN gateway (IPv6)"
+	else
+		echo "FAIL: Cannot ping VPN gateway (IPv6)"
+		exit 1
+	fi
+fi
 
 # Test 3: DNS resolution through Unbound
 echo "Test 3: Testing DNS resolution via Unbound ($VPN_GATEWAY)..."

--- a/test/client-entrypoint.sh
+++ b/test/client-entrypoint.sh
@@ -28,6 +28,7 @@ if [ -f /shared/vpn-config.env ]; then
 	source /shared/vpn-config.env
 	echo "VPN config loaded: VPN_SUBNET_IPV4=$VPN_SUBNET_IPV4, VPN_GATEWAY=$VPN_GATEWAY"
 	if [ "${CLIENT_IPV6:-n}" = "y" ]; then
+		# shellcheck disable=SC2153 # Variables are sourced from vpn-config.env
 		echo "IPv6 enabled: VPN_SUBNET_IPV6=$VPN_SUBNET_IPV6, VPN_GATEWAY_IPV6=$VPN_GATEWAY_IPV6"
 	fi
 else


### PR DESCRIPTION
## Summary

Comprehensive IPv4/IPv6 overhaul that decouples server endpoint addressing from client tunnel addressing, supporting all combinations with automatic leak prevention.

### Supported Configurations

| Endpoint | Client Mode | Description |
|----------|-------------|-------------|
| IPv4 | IPv4-only | Traditional setup (4→4) |
| IPv4 | Dual-stack | IPv4 endpoint, clients get both (4→4/6) |
| IPv4 | IPv6-only | IPv4 endpoint, clients get IPv6 only (4→6) |
| IPv6 | IPv4-only | IPv6 endpoint, clients get IPv4 only (6→4) |
| IPv6 | Dual-stack | IPv6 endpoint, clients get both (6→4/6) |
| IPv6 | IPv6-only | Full IPv6 setup (6→6) |

### Leak Prevention

- **IPv4-only mode**: Pushes `block-ipv6` to clients, blocking all IPv6 traffic
- **IPv6-only mode**: Assigns IPv4 addresses and pushes `redirect-gateway def1` to capture IPv4 traffic, which is then dropped (no IPv4 NAT configured)
- **Dual-stack mode**: Both protocols tunneled normally

### New CLI Options

```
Network Options:
  --endpoint-type <4|6>     Endpoint IP version (default: 4)
  --client-ipv4             Enable IPv4 for VPN clients (default: enabled)
  --no-client-ipv4          Disable IPv4 for VPN clients
  --client-ipv6             Enable IPv6 for VPN clients (default: disabled)
  --no-client-ipv6          Disable IPv6 for VPN clients
  --subnet-ipv4 <x.x.x.0>   IPv4 VPN subnet (default: 10.8.0.0)
  --subnet-ipv6 <prefix>    IPv6 VPN subnet (default: fd42:42:42:42::)
```

### Usage Examples

```bash
# Dual-stack clients (IPv4 + IPv6)
./openvpn-install.sh install --client-ipv4 --client-ipv6

# IPv6-only clients (IPv4 traffic blocked)
./openvpn-install.sh install --no-client-ipv4 --client-ipv6

# IPv4-only clients (IPv6 traffic blocked) - default behavior
./openvpn-install.sh install --client-ipv4 --no-client-ipv6

# IPv6 server endpoint
./openvpn-install.sh install --endpoint-type 6 --endpoint 2001:db8::1

# Custom subnets
./openvpn-install.sh install --client-ipv6 --subnet-ipv4 10.9.0.0 --subnet-ipv6 fd00:1234:5678::
```

### Implementation Details

**Core changes:**
- New `ENDPOINT_TYPE` variable (4 or 6) controls server listening protocol
- New `CLIENT_IPV4`/`CLIENT_IPV6` variables control client tunnel addressing
- Renamed `VPN_SUBNET` → `VPN_SUBNET_IPV4`, added `VPN_SUBNET_IPV6`
- Separate `resolvePublicIPv4()` and `resolvePublicIPv6()` functions
- New `validate_subnet_ipv6()` for ULA (fd00::/8) validation

**Protocol handling:**
- Uses `proto udp6`/`tcp6` when endpoint type is IPv6
- Firewall and SELinux commands handle both protocol variants

**Firewall updates:**
- firewalld: Conditional IPv6 masquerade and forwarding
- nftables: Separate ip/ip6 tables for NAT based on client config
- iptables: ip6tables rules only when IPv6 clients enabled

**DNS configuration:**
- Unbound listens on IPv4/IPv6 gateway addresses as needed
- All third-party DNS providers now include IPv6 servers:
  - Cloudflare: 2606:4700:4700::1111
  - Quad9: 2620:fe::fe
  - Google: 2001:4860:4860::8888
  - OpenDNS: 2620:119:35::35
  - AdGuard: 2a10:50c0::ad1:ff

**CI/Testing:**
- Added `ubuntu-24.04-dual-stack` test matrix entry
- Docker test container enables IPv6 forwarding
- `CLIENT_IPV6` environment variable passed to test container

## Test Plan

- [x] Shellcheck passes
- [x] CI Docker tests pass (including new dual-stack test)
- [x] Manual testing: IPv4-only mode blocks IPv6 traffic
- [x] Manual testing: IPv6-only mode blocks IPv4 traffic
- [x] Manual testing: Dual-stack mode tunnels both protocols

---

Closes #1317
Closes #1288
Closes #1084
Closes #701
Closes #350