### PR TITLE
feat: add TLS 1.3 support, replace ecdh-curve with tls-groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,8 @@ The `install` command supports many options for customization:
 - `--rsa-bits <2048|3072|4096>` - RSA key size (default: `2048`)
 - `--hmac <alg>` - HMAC algorithm (default: `SHA256`). Options: `SHA256`, `SHA384`, `SHA512`
 - `--tls-sig <mode>` - TLS mode (default: `crypt-v2`). Options: `crypt-v2`, `crypt`, `auth`
+- `--tls-version-min <1.2|1.3>` - Minimum TLS version (default: `1.2`)
+- `--tls-ciphersuites <list>` - TLS 1.3 cipher suites, colon-separated (default: `TLS_AES_256_GCM_SHA384:TLS_AES_128_GCM_SHA256:TLS_CHACHA20_POLY1305_SHA256`)
 - `--dh-type <ecdh|dh>` - DH key exchange type (default: `ecdh`)
 - `--dh-curve <curve>` - ECDH curve (default: `prime256v1`). Options: `prime256v1`, `secp384r1`, `secp521r1`
 - `--dh-bits <2048|3072|4096>` - DH key size when using `--dh-type dh` (default: `2048`)
@@ -415,9 +417,17 @@ OpenVPN 2.6+ defaults `--allow-compression` to `no`, blocking even server-pushed
 
 OpenVPN 2.5 and earlier accepted TLS 1.0 by default, which is nearly [20 years old](https://en.wikipedia.org/wiki/Transport_Layer_Security#TLS_1.0).
 
-With `tls-version-min 1.2` we enforce TLS 1.2, which the best protocol available currently for OpenVPN.
+This script defaults to `tls-version-min 1.2` for compatibility with all OpenVPN 2.4+ clients. You can optionally set `tls-version-min 1.3` for environments where all clients support TLS 1.3.
 
-TLS 1.2 is supported since OpenVPN 2.3.3.
+**TLS 1.3 support** was added in OpenVPN 2.5 and requires OpenSSL 1.1.1+. All distributions supported by this script include OpenSSL 1.1.1 or later. TLS 1.3 offers improved security and performance with a simplified handshake.
+
+The script configures TLS 1.3 cipher suites via `--tls-ciphersuites` (separate from the TLS 1.2 `--tls-cipher` option). The default TLS 1.3 cipher suites are:
+
+- `TLS_AES_256_GCM_SHA384`
+- `TLS_AES_128_GCM_SHA256`
+- `TLS_CHACHA20_POLY1305_SHA256`
+
+TLS 1.2 is supported since OpenVPN 2.3.3. TLS 1.3 is supported since OpenVPN 2.5.
 
 ### Certificate
 
@@ -476,6 +486,8 @@ OpenVPN 2.4 added a feature called "NCP": _Negotiable Crypto Parameters_. It mea
 
 OpenVPN 2.4 will negotiate the best cipher available by default (e.g ECDHE+AES-256-GCM)
 
+#### TLS 1.2 ciphers (`--tls-cipher`)
+
 The script proposes the following options, depending on the certificate:
 
 - ECDSA:
@@ -488,6 +500,16 @@ The script proposes the following options, depending on the certificate:
   - `TLS-ECDHE-RSA-WITH-CHACHA20-POLY1305-SHA256` (requires OpenVPN 2.5+)
 
 It defaults to `TLS-ECDHE-*-WITH-AES-128-GCM-SHA256`.
+
+#### TLS 1.3 ciphers (`--tls-ciphersuites`)
+
+When TLS 1.3 is negotiated, a separate set of cipher suites is used. These are configured via `--tls-ciphersuites` and use OpenSSL naming conventions:
+
+- `TLS_AES_256_GCM_SHA384`
+- `TLS_AES_128_GCM_SHA256`
+- `TLS_CHACHA20_POLY1305_SHA256`
+
+By default, all three cipher suites are enabled. TLS 1.3 cipher suites are simpler because they don't include the key exchange algorithm (which is negotiated separately via key shares).
 
 ### Diffie-Hellman key exchange
 

--- a/README.md
+++ b/README.md
@@ -291,9 +291,7 @@ The `install` command supports many options for customization:
 - `--tls-sig <mode>` - TLS mode (default: `crypt-v2`). Options: `crypt-v2`, `crypt`, `auth`
 - `--tls-version-min <1.2|1.3>` - Minimum TLS version (default: `1.2`)
 - `--tls-ciphersuites <list>` - TLS 1.3 cipher suites, colon-separated (default: `TLS_AES_256_GCM_SHA384:TLS_AES_128_GCM_SHA256:TLS_CHACHA20_POLY1305_SHA256`)
-- `--dh-type <ecdh|dh>` - DH key exchange type (default: `ecdh`)
-- `--dh-curve <curve>` - ECDH curve (default: `prime256v1`). Options: `prime256v1`, `secp384r1`, `secp521r1`
-- `--dh-bits <2048|3072|4096>` - DH key size when using `--dh-type dh` (default: `2048`)
+- `--tls-groups <list>` - Key exchange groups, colon-separated (default: `X25519:prime256v1:secp384r1:secp521r1`)
 - `--server-cert-days <n>` - Server cert validity in days (default: `3650`)
 
 **Client Options:**
@@ -419,7 +417,7 @@ OpenVPN 2.5 and earlier accepted TLS 1.0 by default, which is nearly [20 years o
 
 This script defaults to `tls-version-min 1.2` for compatibility with all OpenVPN 2.4+ clients. You can optionally set `tls-version-min 1.3` for environments where all clients support TLS 1.3.
 
-**TLS 1.3 support** was added in OpenVPN 2.5 and requires OpenSSL 1.1.1+. All distributions supported by this script include OpenSSL 1.1.1 or later. TLS 1.3 offers improved security and performance with a simplified handshake.
+**TLS 1.3 support** was added in OpenVPN 2.5 and requires OpenSSL 1.1.1+. TLS 1.3 offers improved security and performance with a simplified handshake.
 
 The script configures TLS 1.3 cipher suites via `--tls-ciphersuites` (separate from the TLS 1.2 `--tls-cipher` option). The default TLS 1.3 cipher suites are:
 
@@ -511,20 +509,24 @@ When TLS 1.3 is negotiated, a separate set of cipher suites is used. These are c
 
 By default, all three cipher suites are enabled. TLS 1.3 cipher suites are simpler because they don't include the key exchange algorithm (which is negotiated separately via key shares).
 
-### Diffie-Hellman key exchange
+### Key exchange
 
-OpenVPN uses a 2048 bits DH key by default.
+OpenVPN historically defaulted to 2048-bit DH parameters for key exchange. This script used to offer both DH (with configurable key sizes) and ECDH as alternatives.
 
-OpenVPN 2.4 added support for ECDH keys. Elliptic curve cryptography is faster, lighter and more secure.
+OpenVPN 2.4 added ECDH support, and OpenVPN 2.7 made `dh none` (ECDH) the default, as finite-field DH is being deprecated. Since ECDH is now universally supported and preferred, this script no longer offers traditional DH.
 
-Also, generating a classic DH keys can take a long, looong time. ECDH keys are ephemeral: they are generated on-the-fly.
+The script configures `tls-groups` with the following preference list:
 
-The script provides the following options:
+```
+X25519:prime256v1:secp384r1:secp521r1
+```
 
-- ECDH: `prime256v1`/`secp384r1`/`secp521r1` curves
-- DH: `2048`/`3072`/`4096` bits keys
+- **X25519**: Fast, modern curve (Curve25519), widely supported
+- **prime256v1**: NIST P-256, most compatible
+- **secp384r1**: NIST P-384, higher security
+- **secp521r1**: NIST P-521, highest security
 
-It defaults to `prime256v1`.
+You can customize this with `--tls-groups`.
 
 ### HMAC digest algorithm
 

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -781,11 +781,9 @@ cmd_install() {
 		# Multi-client
 		MULTI_CLIENT=${MULTI_CLIENT:-n}
 
-		# Encryption
+		# Encryption - always set defaults for any missing values
 		CUSTOMIZE_ENC=${CUSTOMIZE_ENC:-n}
-		if [[ $CUSTOMIZE_ENC == "n" ]]; then
-			set_default_encryption
-		fi
+		set_default_encryption
 
 		# Client setup
 		if [[ $no_client == true ]]; then
@@ -1856,6 +1854,9 @@ function installQuestions() {
 		CERT_TYPE="1" # ECDSA
 		CERT_CURVE="prime256v1"
 		CC_CIPHER="TLS-ECDHE-ECDSA-WITH-AES-128-GCM-SHA256"
+		TLS13_CIPHERSUITES="TLS_AES_256_GCM_SHA384:TLS_AES_128_GCM_SHA256:TLS_CHACHA20_POLY1305_SHA256"
+		TLS_VERSION_MIN="1.2"
+		TLS_GROUPS="X25519:prime256v1:secp384r1:secp521r1"
 		HMAC_ALG="SHA256"
 		TLS_SIG="1" # tls-crypt-v2
 	else
@@ -2023,6 +2024,25 @@ function installQuestions() {
 			;;
 		4)
 			TLS13_CIPHERSUITES="TLS_CHACHA20_POLY1305_SHA256"
+			;;
+		esac
+		log_menu ""
+		log_prompt "Choose TLS key exchange groups (for ECDH key exchange):"
+		log_menu "   1) All modern curves (recommended)"
+		log_menu "   2) X25519 only (most secure, may have compatibility issues)"
+		log_menu "   3) NIST curves only (prime256v1, secp384r1, secp521r1)"
+		until [[ $TLS_GROUPS_CHOICE =~ ^[1-3]$ ]]; do
+			read -rp "TLS groups [1-3]: " -e -i 1 TLS_GROUPS_CHOICE
+		done
+		case $TLS_GROUPS_CHOICE in
+		1)
+			TLS_GROUPS="X25519:prime256v1:secp384r1:secp521r1"
+			;;
+		2)
+			TLS_GROUPS="X25519"
+			;;
+		3)
+			TLS_GROUPS="prime256v1:secp384r1:secp521r1"
 			;;
 		esac
 		log_menu ""


### PR DESCRIPTION
## Summary

- Add TLS 1.3 support with `--tls-version-min` and `--tls-ciphersuites`
- Replace deprecated `ecdh-curve` with `tls-groups`
- Remove traditional DH support (OpenVPN 2.7 defaults to ECDH)

## New options

| Option | Default |
|--------|---------|
| `--tls-version-min` | `1.2` |
| `--tls-ciphersuites` | `TLS_AES_256_GCM_SHA384:TLS_AES_128_GCM_SHA256:TLS_CHACHA20_POLY1305_SHA256` |
| `--tls-groups` | `X25519:prime256v1:secp384r1:secp521r1` |

## Removed

- `--dh-type`, `--dh-bits`, `--dh-curve`
- DH parameter generation

Closes https://github.com/angristan/openvpn-install/issues/1231
Closes https://github.com/angristan/openvpn-install/issues/637
Closes https://github.com/angristan/openvpn-install/issues/1362