### PR TITLE
fix: prevent duplicate install questions and MTU prompt in CLI mode

### DIFF
--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -2136,9 +2136,6 @@ function installOpenVPN() {
 		log_info "  SERVER_CERT_DURATION_DAYS=$SERVER_CERT_DURATION_DAYS"
 	fi
 
-	# Run setup questions first, and set other variables if auto-install
-	installQuestions
-
 	# Get the "public" interface from the default route
 	NIC=$(ip -4 route ls | grep default | grep -Po '(?<=dev )(\S+)' | head -1)
 	if [[ -z $NIC ]] && [[ $IPV6_SUPPORT == 'y' ]]; then

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -781,6 +781,13 @@ cmd_install() {
 		# Multi-client
 		MULTI_CLIENT=${MULTI_CLIENT:-n}
 
+		# MTU
+		if [[ -n $MTU ]]; then
+			MTU_CHOICE=2
+		else
+			MTU_CHOICE=${MTU_CHOICE:-1}
+		fi
+
 		# Encryption - always set defaults for any missing values
 		CUSTOMIZE_ENC=${CUSTOMIZE_ENC:-n}
 		set_default_encryption

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -806,6 +806,7 @@ cmd_install() {
 		SERVER_CERT_DURATION_DAYS=${SERVER_CERT_DURATION_DAYS:-$DEFAULT_CERT_VALIDITY_DURATION_DAYS}
 		CONTINUE=y
 
+		installQuestions
 		installOpenVPN
 	fi
 }


### PR DESCRIPTION
## Summary

Fixed a bug where installation questions were asked twice in interactive mode, and a related bug where the MTU choice prompt appeared in non-interactive CLI mode.

**Root cause:** `installQuestions()` was being called both by the caller (`cmd_install()` or `cmd_interactive()`) and again inside `installOpenVPN()`.

**Changes:**
- Removed the redundant `installQuestions()` call from `installOpenVPN()`
- Added `installQuestions()` call to the non-interactive branch of `cmd_install()` (needed for IP detection and setup)
- Added `MTU_CHOICE` default to the non-interactive branch (was previously set inside `installOpenVPN()` before calling `installQuestions()`)