### PR TITLE
fix: simplify e2e test wait loops to prevent flaky failures

### DIFF
--- a/test/client-entrypoint.sh
+++ b/test/client-entrypoint.sh
@@ -3,23 +3,6 @@ set -e
 
 echo "=== OpenVPN Client Container ==="
 
-# Helper function for connectivity checks - retries indefinitely
-# Relies on job-level timeout (5min) to fail if connectivity never works
-# Usage: wait_for_ping <host>
-wait_for_ping() {
-	local host="$1"
-	local attempt=1
-
-	while true; do
-		if ping -c 3 -W 2 "$host" >/dev/null 2>&1; then
-			return 0
-		fi
-		echo "Ping attempt $attempt to $host failed, retrying in 3s..."
-		attempt=$((attempt + 1))
-		sleep 3
-	done
-}
-
 # Create TUN device if it doesn't exist
 if [ ! -c /dev/net/tun ]; then
 	mkdir -p /dev/net
@@ -90,7 +73,10 @@ fi
 
 # Test 2: Ping VPN gateway (retries indefinitely, relies on job timeout)
 echo "Test 2: Pinging VPN gateway ($VPN_GATEWAY)..."
-wait_for_ping "$VPN_GATEWAY"
+while ! ping -c 3 -W 2 "$VPN_GATEWAY" >/dev/null 2>&1; do
+	echo "Ping failed, retrying..."
+	sleep 3
+done
 echo "PASS: Can ping VPN gateway"
 
 # Test 3: DNS resolution through Unbound
@@ -167,7 +153,10 @@ echo "PASS: Connected with '$REVOKE_CLIENT' certificate"
 ip addr show tun0
 
 # Verify connectivity (retries indefinitely, relies on job timeout)
-wait_for_ping "$VPN_GATEWAY"
+while ! ping -c 3 -W 2 "$VPN_GATEWAY" >/dev/null 2>&1; do
+	echo "Ping failed, retrying..."
+	sleep 3
+done
 echo "PASS: Can ping VPN gateway with revoke test client"
 
 # Signal server that we're connected with revoke test client
@@ -301,7 +290,10 @@ echo "PASS: Connected with new '$REVOKE_CLIENT' certificate"
 ip addr show tun0
 
 # Verify connectivity (retries indefinitely, relies on job timeout)
-wait_for_ping "$VPN_GATEWAY"
+while ! ping -c 3 -W 2 "$VPN_GATEWAY" >/dev/null 2>&1; do
+	echo "Ping failed, retrying..."
+	sleep 3
+done
 echo "PASS: Can ping VPN gateway with new certificate"
 
 # Signal server that we connected with new cert
@@ -360,7 +352,10 @@ echo "PASS: Connected with passphrase-protected '$PASSPHRASE_CLIENT' certificate
 ip addr show tun0
 
 # Verify connectivity (retries indefinitely, relies on job timeout)
-wait_for_ping "$VPN_GATEWAY"
+while ! ping -c 3 -W 2 "$VPN_GATEWAY" >/dev/null 2>&1; do
+	echo "Ping failed, retrying..."
+	sleep 3
+done
 echo "PASS: Can ping VPN gateway with passphrase-protected client"
 
 # Signal server that we connected with passphrase client

--- a/test/client-entrypoint.sh
+++ b/test/client-entrypoint.sh
@@ -10,12 +10,12 @@ wait_for_ping() {
 	local max_retries="${2:-10}"
 	local retry_delay="${3:-3}"
 
-	for i in $(seq 1 $max_retries); do
+	for i in $(seq 1 "$max_retries"); do
 		if ping -c 3 -W 2 "$host" >/dev/null 2>&1; then
 			return 0
 		fi
 		echo "Ping attempt $i/$max_retries to $host failed, retrying in ${retry_delay}s..."
-		sleep "$retry_delay"
+		sleep "${retry_delay}"
 	done
 	return 1
 }

--- a/test/client-entrypoint.sh
+++ b/test/client-entrypoint.sh
@@ -12,7 +12,7 @@ fi
 
 echo "TUN device ready"
 
-# Wait for client config to be available (relies on job timeout)
+# Wait for client config to be available
 echo "Waiting for client config..."
 while [ ! -f /shared/client.ovpn ]; do
 	sleep 2
@@ -37,7 +37,7 @@ fi
 echo "Connecting to OpenVPN server..."
 openvpn --config /shared/client.ovpn --daemon --log /var/log/openvpn.log
 
-# Wait for connection (relies on job timeout)
+# Wait for connection
 echo "Waiting for VPN connection..."
 while ! ip addr show tun0 2>/dev/null | grep -q "inet "; do
 	sleep 2
@@ -116,7 +116,7 @@ echo "=== Starting Certificate Revocation E2E Tests ==="
 
 REVOKE_CLIENT="revoketest"
 
-# Wait for revoke test client config (relies on job timeout)
+# Wait for revoke test client config
 echo "Waiting for revoke test client config..."
 while [ ! -f /shared/revoke-client-config-ready ]; do
 	sleep 2
@@ -139,7 +139,7 @@ sleep 2
 echo "Connecting with '$REVOKE_CLIENT' certificate..."
 openvpn --config "/shared/$REVOKE_CLIENT.ovpn" --daemon --log /var/log/openvpn-revoke.log
 
-# Wait for connection (relies on job timeout)
+# Wait for connection
 echo "Waiting for VPN connection with revoke test client..."
 while ! ip addr show tun0 2>/dev/null | grep -q "inet "; do
 	sleep 2
@@ -162,7 +162,7 @@ echo "PASS: Can ping VPN gateway with revoke test client"
 # Signal server that we're connected with revoke test client
 touch /shared/revoke-client-connected
 
-# Wait for server to signal us to disconnect (relies on job timeout)
+# Wait for server to signal us to disconnect
 echo "Waiting for server to signal disconnect..."
 while [ ! -f /shared/revoke-client-disconnect ]; do
 	sleep 2
@@ -190,7 +190,7 @@ echo "PASS: Disconnected successfully"
 # Signal server that we're disconnected
 touch /shared/revoke-client-disconnected
 
-# Wait for server to revoke the certificate and signal us to reconnect (relies on job timeout)
+# Wait for server to revoke the certificate and signal us to reconnect
 echo "Waiting for server to revoke certificate and signal reconnect..."
 while [ ! -f /shared/revoke-try-reconnect ]; do
 	sleep 2
@@ -201,7 +201,7 @@ echo "Attempting to reconnect with revoked certificate (should fail)..."
 rm -f /var/log/openvpn-revoke-fail.log
 openvpn --config "/shared/$REVOKE_CLIENT.ovpn" --daemon --log /var/log/openvpn-revoke-fail.log
 
-# Wait and check if connection fails (relies on job timeout)
+# Wait and check if connection fails
 # The connection should fail due to certificate being revoked
 echo "Waiting to verify connection is rejected..."
 CONNECT_FAILED=false
@@ -257,7 +257,7 @@ touch /shared/revoke-reconnect-failed
 echo ""
 echo "=== Testing connection with recreated certificate ==="
 
-# Wait for server to create new cert and signal us (relies on job timeout)
+# Wait for server to create new cert and signal us
 echo "Waiting for new client config with same name..."
 while [ ! -f /shared/new-client-config-ready ]; do
 	sleep 2
@@ -276,7 +276,7 @@ echo "Connecting with new '$REVOKE_CLIENT' certificate..."
 rm -f /var/log/openvpn-new.log
 openvpn --config "/shared/$REVOKE_CLIENT-new.ovpn" --daemon --log /var/log/openvpn-new.log
 
-# Wait for connection (relies on job timeout)
+# Wait for connection
 echo "Waiting for VPN connection with new certificate..."
 while ! ip addr show tun0 2>/dev/null | grep -q "inet "; do
 	sleep 2
@@ -310,7 +310,7 @@ echo "=== Testing PASSPHRASE-protected Client Connection ==="
 
 PASSPHRASE_CLIENT="passphrasetest"
 
-# Wait for passphrase test client config (relies on job timeout)
+# Wait for passphrase test client config
 echo "Waiting for passphrase test client config..."
 while [ ! -f /shared/passphrase-client-config-ready ]; do
 	sleep 2
@@ -338,7 +338,7 @@ sleep 2
 echo "Connecting with '$PASSPHRASE_CLIENT' certificate (passphrase-protected)..."
 openvpn --config "/shared/$PASSPHRASE_CLIENT.ovpn" --askpass "/shared/$PASSPHRASE_CLIENT.pass" --daemon --log /var/log/openvpn-passphrase.log
 
-# Wait for connection (relies on job timeout)
+# Wait for connection
 echo "Waiting for VPN connection with passphrase-protected client..."
 while ! ip addr show tun0 2>/dev/null | grep -q "inet "; do
 	sleep 2

--- a/test/server-entrypoint.sh
+++ b/test/server-entrypoint.sh
@@ -665,22 +665,14 @@ echo "Allowing routing to stabilize..."
 sleep 3
 
 # =====================================================
-# Wait for initial client tests to complete
+# Wait for initial client tests to complete (relies on job timeout)
 # =====================================================
 echo ""
 echo "=== Waiting for initial client connectivity tests ==="
-MAX_WAIT=120
-WAITED=0
-while [ ! -f /shared/initial-tests-passed ] && [ $WAITED -lt $MAX_WAIT ]; do
+while [ ! -f /shared/initial-tests-passed ]; do
 	sleep 2
-	WAITED=$((WAITED + 2))
-	echo "Waiting for initial tests... ($WAITED/$MAX_WAIT seconds)"
+	echo "Waiting for initial tests..."
 done
-
-if [ ! -f /shared/initial-tests-passed ]; then
-	echo "ERROR: Initial client tests did not complete in time"
-	exit 1
-fi
 echo "Initial client tests passed, proceeding with revocation tests"
 
 # =====================================================
@@ -711,20 +703,12 @@ echo "Copied $REVOKE_CLIENT config to /shared/"
 # Signal client that revoke test config is ready
 touch /shared/revoke-client-config-ready
 
-# Wait for client to confirm connection with revoke test client
+# Wait for client to confirm connection with revoke test client (relies on job timeout)
 echo "Waiting for client to connect with '$REVOKE_CLIENT' certificate..."
-MAX_WAIT=60
-WAITED=0
-while [ ! -f /shared/revoke-client-connected ] && [ $WAITED -lt $MAX_WAIT ]; do
+while [ ! -f /shared/revoke-client-connected ]; do
 	sleep 2
-	WAITED=$((WAITED + 2))
-	echo "Waiting for revoke test connection... ($WAITED/$MAX_WAIT seconds)"
+	echo "Waiting for revoke test connection..."
 done
-
-if [ ! -f /shared/revoke-client-connected ]; then
-	echo "ERROR: Client did not connect with revoke test certificate"
-	exit 1
-fi
 echo "PASS: Client connected with '$REVOKE_CLIENT' certificate"
 
 # =====================================================
@@ -766,19 +750,11 @@ echo "=== Server Status Tests PASSED ==="
 # Signal client to disconnect before revocation
 touch /shared/revoke-client-disconnect
 
-# Wait for client to disconnect
+# Wait for client to disconnect (relies on job timeout)
 echo "Waiting for client to disconnect..."
-MAX_WAIT=30
-WAITED=0
-while [ ! -f /shared/revoke-client-disconnected ] && [ $WAITED -lt $MAX_WAIT ]; do
+while [ ! -f /shared/revoke-client-disconnected ]; do
 	sleep 2
-	WAITED=$((WAITED + 2))
 done
-
-if [ ! -f /shared/revoke-client-disconnected ]; then
-	echo "ERROR: Client did not signal disconnect"
-	exit 1
-fi
 echo "Client disconnected"
 
 # Now revoke the certificate
@@ -806,20 +782,12 @@ fi
 # Signal client to try reconnecting (should fail)
 touch /shared/revoke-try-reconnect
 
-# Wait for client to confirm that connection with revoked cert failed
+# Wait for client to confirm that connection with revoked cert failed (relies on job timeout)
 echo "Waiting for client to confirm revoked cert connection failure..."
-MAX_WAIT=60
-WAITED=0
-while [ ! -f /shared/revoke-reconnect-failed ] && [ $WAITED -lt $MAX_WAIT ]; do
+while [ ! -f /shared/revoke-reconnect-failed ]; do
 	sleep 2
-	WAITED=$((WAITED + 2))
-	echo "Waiting for reconnect failure confirmation... ($WAITED/$MAX_WAIT seconds)"
+	echo "Waiting for reconnect failure confirmation..."
 done
-
-if [ ! -f /shared/revoke-reconnect-failed ]; then
-	echo "ERROR: Client did not confirm that revoked cert connection failed"
-	exit 1
-fi
 echo "PASS: Connection with revoked certificate correctly rejected"
 
 echo "=== Certificate Revocation Tests PASSED ==="
@@ -955,20 +923,12 @@ echo "Copied new $REVOKE_CLIENT config to /shared/"
 # Signal client that new config is ready
 touch /shared/new-client-config-ready
 
-# Wait for client to confirm successful connection with new cert
+# Wait for client to confirm successful connection with new cert (relies on job timeout)
 echo "Waiting for client to connect with new '$REVOKE_CLIENT' certificate..."
-MAX_WAIT=60
-WAITED=0
-while [ ! -f /shared/new-client-connected ] && [ $WAITED -lt $MAX_WAIT ]; do
+while [ ! -f /shared/new-client-connected ]; do
 	sleep 2
-	WAITED=$((WAITED + 2))
-	echo "Waiting for new cert connection... ($WAITED/$MAX_WAIT seconds)"
+	echo "Waiting for new cert connection..."
 done
-
-if [ ! -f /shared/new-client-connected ]; then
-	echo "ERROR: Client did not connect with new certificate"
-	exit 1
-fi
 echo "PASS: Client connected with new '$REVOKE_CLIENT' certificate"
 
 echo "=== Reuse of Revoked Client Name Tests PASSED ==="
@@ -1034,20 +994,12 @@ echo "Copied $PASSPHRASE_CLIENT config and passphrase to /shared/"
 # Signal client that passphrase test config is ready
 touch /shared/passphrase-client-config-ready
 
-# Wait for client to confirm connection with passphrase client
+# Wait for client to confirm connection with passphrase client (relies on job timeout)
 echo "Waiting for client to connect with '$PASSPHRASE_CLIENT' certificate..."
-MAX_WAIT=60
-WAITED=0
-while [ ! -f /shared/passphrase-client-connected ] && [ $WAITED -lt $MAX_WAIT ]; do
+while [ ! -f /shared/passphrase-client-connected ]; do
 	sleep 2
-	WAITED=$((WAITED + 2))
-	echo "Waiting for passphrase client connection... ($WAITED/$MAX_WAIT seconds)"
+	echo "Waiting for passphrase client connection..."
 done
-
-if [ ! -f /shared/passphrase-client-connected ]; then
-	echo "FAIL: Client did not connect with passphrase-protected certificate"
-	exit 1
-fi
 echo "PASS: Client connected with passphrase-protected certificate"
 
 echo "=== PASSPHRASE Support Tests PASSED ==="

--- a/test/server-entrypoint.sh
+++ b/test/server-entrypoint.sh
@@ -665,7 +665,7 @@ echo "Allowing routing to stabilize..."
 sleep 3
 
 # =====================================================
-# Wait for initial client tests to complete (relies on job timeout)
+# Wait for initial client tests to complete
 # =====================================================
 echo ""
 echo "=== Waiting for initial client connectivity tests ==="
@@ -703,7 +703,7 @@ echo "Copied $REVOKE_CLIENT config to /shared/"
 # Signal client that revoke test config is ready
 touch /shared/revoke-client-config-ready
 
-# Wait for client to confirm connection with revoke test client (relies on job timeout)
+# Wait for client to confirm connection with revoke test client
 echo "Waiting for client to connect with '$REVOKE_CLIENT' certificate..."
 while [ ! -f /shared/revoke-client-connected ]; do
 	sleep 2
@@ -750,7 +750,7 @@ echo "=== Server Status Tests PASSED ==="
 # Signal client to disconnect before revocation
 touch /shared/revoke-client-disconnect
 
-# Wait for client to disconnect (relies on job timeout)
+# Wait for client to disconnect
 echo "Waiting for client to disconnect..."
 while [ ! -f /shared/revoke-client-disconnected ]; do
 	sleep 2
@@ -782,7 +782,7 @@ fi
 # Signal client to try reconnecting (should fail)
 touch /shared/revoke-try-reconnect
 
-# Wait for client to confirm that connection with revoked cert failed (relies on job timeout)
+# Wait for client to confirm that connection with revoked cert failed
 echo "Waiting for client to confirm revoked cert connection failure..."
 while [ ! -f /shared/revoke-reconnect-failed ]; do
 	sleep 2
@@ -923,7 +923,7 @@ echo "Copied new $REVOKE_CLIENT config to /shared/"
 # Signal client that new config is ready
 touch /shared/new-client-config-ready
 
-# Wait for client to confirm successful connection with new cert (relies on job timeout)
+# Wait for client to confirm successful connection with new cert
 echo "Waiting for client to connect with new '$REVOKE_CLIENT' certificate..."
 while [ ! -f /shared/new-client-connected ]; do
 	sleep 2
@@ -994,7 +994,7 @@ echo "Copied $PASSPHRASE_CLIENT config and passphrase to /shared/"
 # Signal client that passphrase test config is ready
 touch /shared/passphrase-client-config-ready
 
-# Wait for client to confirm connection with passphrase client (relies on job timeout)
+# Wait for client to confirm connection with passphrase client
 echo "Waiting for client to connect with '$PASSPHRASE_CLIENT' certificate..."
 while [ ! -f /shared/passphrase-client-connected ]; do
 	sleep 2


### PR DESCRIPTION
## Summary

- Replace all fixed-timeout wait loops with simple indefinite `while` loops
- Add 5-second stabilization delay after VPN connection before running ping tests
- Add server-side tun0 interface verification before signaling client
- Add wait for OpenVPN restart after server certificate renewal

## Problem

Tests fail randomly with errors like:
```
Test 2: Pinging VPN gateway (10.9.0.1)...
10 packets transmitted, 0 received, 100% packet loss
FAIL: Cannot ping VPN gateway
```

Example: https://github.com/angristan/openvpn-install/actions/runs/20230801728/job/58072998112

## Solution

Instead of guessing timeout values that may be too short for slow CI runners, all wait loops now run indefinitely and rely on the job-level timeout to catch actual failures.

**Before:**
```bash
MAX_WAIT=60
WAITED=0
while [ condition ] && [ $WAITED -lt $MAX_WAIT ]; do
    sleep 2
    WAITED=$((WAITED + 2))
done
if [ condition ]; then exit 1; fi
```

**After:**
```bash
while [ condition ]; do
    sleep 2
done
```

This removes 83 lines of boilerplate timeout logic.