### PR TITLE
fix: use source-based firewall rules with interface wildcard matching

### DIFF
--- a/test/server-entrypoint.sh
+++ b/test/server-entrypoint.sh
@@ -571,7 +571,7 @@ if systemctl is-active --quiet firewalld; then
 		firewall-cmd --list-ports
 		exit 1
 	fi
-	# Verify VPN subnet rich rule exists
+	# Verify VPN subnet rich rule exists (source-based rules work reliably across firewalld backends)
 	if firewall-cmd --list-rich-rules | grep -q "source address=\"$VPN_SUBNET_IPV4/24\""; then
 		echo "PASS: VPN subnet rich rule is configured"
 	else


### PR DESCRIPTION
## Summary

- Fixes firewall rules that hardcode `tun0` interface, which fails when OpenVPN uses `tun1`, `tun2`, etc. because another service already occupies `tun0`
- Uses a defense-in-depth approach combining interface wildcard matching with source-based rules to prevent IP spoofing

Fixes #1298

## Changes

| Backend | Before | After |
|---------|--------|-------|
| **iptables** | `-i tun0` | `-i tun+ -s $VPN_SUBNET` |
| **nftables** | `iifname "tun0"` | `iifname "tun*" ip saddr $VPN_SUBNET` |
| **firewalld** | rich rules (source-based) | no change needed |

## Implementation Details

- **iptables/nftables**: Combined interface wildcard (`tun+`/`tun*`) with source matching provides defense in depth - traffic must come from both a tun interface AND the VPN subnet
- **firewalld**: Already used source-based rich rules, so no changes required (rich rules work reliably across both iptables and nftables backends)