### PR TITLE
feat: disconnect clients immediately on certificate revocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ That said, OpenVPN still makes sense when you need:
 - CLI interface for automation and scripting (non-interactive mode with JSON output)
 - Certificate renewal for both client and server certificates
 - List and monitor connected clients
+- Immediate client disconnect on certificate revocation (via management interface)
 - Uses [official OpenVPN repositories](https://community.openvpn.net/openvpn/wiki/OpenvpnSoftwareRepos) when possible for the latest stable releases
 - Firewall rules and forwarding managed seamlessly (native firewalld and nftables support, iptables fallback)
 - Configurable VPN subnets (IPv4: default `10.8.0.0/24`, IPv6: default `fd42:42:42:42::/112`)
@@ -135,7 +136,7 @@ For automation and scripting, use the CLI interface:
 # List clients
 ./openvpn-install.sh client list
 
-# Revoke a client
+# Revoke a client (immediately disconnects if connected)
 ./openvpn-install.sh client revoke alice
 ```
 

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -2473,20 +2473,21 @@ function installOpenVPN() {
 		installOpenVPNRepo
 
 		log_info "Installing OpenVPN and dependencies..."
+		# socat is used for communicating with the OpenVPN management interface (client disconnect on revoke)
 		if [[ $OS =~ (debian|ubuntu) ]]; then
-			run_cmd_fatal "Installing OpenVPN" apt-get install -y openvpn iptables openssl curl ca-certificates tar dnsutils
+			run_cmd_fatal "Installing OpenVPN" apt-get install -y openvpn iptables openssl curl ca-certificates tar dnsutils socat
 		elif [[ $OS == 'centos' ]]; then
-			run_cmd_fatal "Installing OpenVPN" yum install -y openvpn iptables openssl ca-certificates curl tar bind-utils 'policycoreutils-python*'
+			run_cmd_fatal "Installing OpenVPN" yum install -y openvpn iptables openssl ca-certificates curl tar bind-utils socat 'policycoreutils-python*'
 		elif [[ $OS == 'oracle' ]]; then
-			run_cmd_fatal "Installing OpenVPN" yum install -y openvpn iptables openssl ca-certificates curl tar bind-utils policycoreutils-python-utils
+			run_cmd_fatal "Installing OpenVPN" yum install -y openvpn iptables openssl ca-certificates curl tar bind-utils socat policycoreutils-python-utils
 		elif [[ $OS == 'amzn2023' ]]; then
-			run_cmd_fatal "Installing OpenVPN" dnf install -y openvpn iptables openssl ca-certificates curl tar bind-utils
+			run_cmd_fatal "Installing OpenVPN" dnf install -y openvpn iptables openssl ca-certificates curl tar bind-utils socat
 		elif [[ $OS == 'fedora' ]]; then
-			run_cmd_fatal "Installing OpenVPN" dnf install -y openvpn iptables openssl ca-certificates curl tar bind-utils policycoreutils-python-utils
+			run_cmd_fatal "Installing OpenVPN" dnf install -y openvpn iptables openssl ca-certificates curl tar bind-utils socat policycoreutils-python-utils
 		elif [[ $OS == 'opensuse' ]]; then
-			run_cmd_fatal "Installing OpenVPN" zypper install -y openvpn iptables openssl ca-certificates curl tar bind-utils
+			run_cmd_fatal "Installing OpenVPN" zypper install -y openvpn iptables openssl ca-certificates curl tar bind-utils socat
 		elif [[ $OS == 'arch' ]]; then
-			run_cmd_fatal "Installing OpenVPN" pacman --needed --noconfirm -Syu openvpn iptables openssl ca-certificates curl tar bind
+			run_cmd_fatal "Installing OpenVPN" pacman --needed --noconfirm -Syu openvpn iptables openssl ca-certificates curl tar bind socat
 		fi
 
 		# Verify ChaCha20-Poly1305 compatibility if selected
@@ -2845,7 +2846,11 @@ tls-cipher $CC_CIPHER
 tls-ciphersuites $TLS13_CIPHERSUITES
 client-config-dir ccd
 status /var/log/openvpn/status.log
+management /var/run/openvpn/server.sock unix
 verb 3" >>/etc/openvpn/server/server.conf
+
+	# Create management socket directory
+	run_cmd_fatal "Creating management socket directory" mkdir -p /var/run/openvpn
 
 	# Create client-config-dir dir
 	run_cmd_fatal "Creating client config directory" mkdir -p /etc/openvpn/server/ccd
@@ -3626,7 +3631,28 @@ function revokeClient() {
 	run_cmd "Removing IP assignment" sed -i "/^$CLIENT,.*/d" /etc/openvpn/server/ipp.txt
 	run_cmd "Backing up index" cp /etc/openvpn/server/easy-rsa/pki/index.txt{,.bk}
 
+	# Disconnect the client if currently connected
+	disconnectClient "$CLIENT"
+
 	log_success "Certificate for client $CLIENT revoked."
+}
+
+# Disconnect a client via the management interface
+function disconnectClient() {
+	local client_name="$1"
+	local mgmt_socket="/var/run/openvpn/server.sock"
+
+	if [[ ! -S "$mgmt_socket" ]]; then
+		log_warning "Management socket not found. Client may still be connected until they reconnect."
+		return 0
+	fi
+
+	log_info "Disconnecting client $client_name..."
+	if echo "kill $client_name" | socat - UNIX-CONNECT:"$mgmt_socket" >/dev/null 2>&1; then
+		log_success "Client $client_name disconnected."
+	else
+		log_warning "Could not disconnect client (they may not be connected)."
+	fi
 }
 
 function renewClient() {

--- a/test/Dockerfile.server
+++ b/test/Dockerfile.server
@@ -15,6 +15,7 @@ ENV ENABLE_NFTABLES=${ENABLE_NFTABLES}
 
 # Install basic dependencies based on the OS
 # dnsutils/bind-utils provides dig for DNS testing with Unbound
+# Note: socat is installed by openvpn-install.sh during OpenVPN installation
 RUN if command -v apt-get >/dev/null; then \
         apt-get update && apt-get install -y --no-install-recommends \
             iproute2 iptables curl procps systemd systemd-sysv dnsutils jq \


### PR DESCRIPTION
## Summary

Adds immediate client disconnect when a certificate is revoked, via OpenVPN management interface.

Previously, revoked clients stayed connected until they voluntarily disconnected or the server restarted.

Fixes #1199

## Changes

- Enable management interface (Unix socket at `/var/run/openvpn/server.sock`)
- Add `disconnectClient()` function to send `kill` command on revoke
- Add `socat` dependency for socket communication