### PR TITLE
docs: add FAQ entry for server-side split-tunnel configuration

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -164,6 +164,42 @@ So for example - here it would route all traffic of `10.0.0.0/8` to the VPN. And
 
 ---
 
+**Q:** How do I configure split-tunnel mode on the server (route only specific networks through VPN for all clients)?
+
+**A:** By default, the script configures full-tunnel mode where all client traffic goes through the VPN. To configure split-tunnel (only specific networks routed through VPN), edit `/etc/openvpn/server/server.conf`:
+
+1. Remove or comment out the redirect-gateway line:
+   ```
+   #push "redirect-gateway def1 bypass-dhcp"
+   ```
+
+2. Add routes for the networks you want to tunnel:
+   ```
+   push "route 10.0.0.0 255.0.0.0"
+   push "route 192.168.1.0 255.255.255.0"
+   ```
+
+3. Optionally remove DNS push directives if you don't want VPN DNS:
+   ```
+   #push "dhcp-option DNS 1.1.1.1"
+   ```
+
+4. For IPv6, remove or comment out:
+   ```
+   #push "route-ipv6 2000::/3"
+   #push "redirect-gateway ipv6"
+   ```
+   Or add specific IPv6 routes:
+   ```
+   push "route-ipv6 2001:db8::/32"
+   ```
+
+5. Restart OpenVPN: `systemctl restart openvpn-server@server`
+
+**Security note:** Split-tunnel mode means non-routed traffic (including potentially DNS queries) bypasses the VPN and is visible to your local network. Only use this if you understand the privacy implications.
+
+---
+
 **Q:** I have enabled IPv6 and my VPN client gets an IPv6 address. Why do I reach the sites or other dual-stacked destinations via IPv4 only?
 
 **A:** This is because inside the tunnel you don't get a publicly routable IPv6 address, instead you get an ULA (Unlique Local Lan) address. Operating systems don't prefer this all the time. You can fix this in your operating system policies as it's unrelated to the VPN itself:

--- a/FAQ.md
+++ b/FAQ.md
@@ -169,27 +169,33 @@ So for example - here it would route all traffic of `10.0.0.0/8` to the VPN. And
 **A:** By default, the script configures full-tunnel mode where all client traffic goes through the VPN. To configure split-tunnel (only specific networks routed through VPN), edit `/etc/openvpn/server/server.conf`:
 
 1. Remove or comment out the redirect-gateway line:
+
    ```
    #push "redirect-gateway def1 bypass-dhcp"
    ```
 
 2. Add routes for the networks you want to tunnel:
+
    ```
    push "route 10.0.0.0 255.0.0.0"
    push "route 192.168.1.0 255.255.255.0"
    ```
 
 3. Optionally remove DNS push directives if you don't want VPN DNS:
+
    ```
    #push "dhcp-option DNS 1.1.1.1"
    ```
 
 4. For IPv6, remove or comment out:
+
    ```
    #push "route-ipv6 2000::/3"
    #push "redirect-gateway ipv6"
    ```
+
    Or add specific IPv6 routes:
+
    ```
    push "route-ipv6 2001:db8::/32"
    ```

--- a/FAQ.md
+++ b/FAQ.md
@@ -202,8 +202,6 @@ So for example - here it would route all traffic of `10.0.0.0/8` to the VPN. And
 
 5. Restart OpenVPN: `systemctl restart openvpn-server@server`
 
-**Security note:** Split-tunnel mode means non-routed traffic (including potentially DNS queries) bypasses the VPN and is visible to your local network. Only use this if you understand the privacy implications.
-
 ---
 
 **Q:** I have enabled IPv6 and my VPN client gets an IPv6 address. Why do I reach the sites or other dual-stacked destinations via IPv4 only?


### PR DESCRIPTION
Adds FAQ entry for server-side split-tunnel configuration.

Closes #443. The script is focused on the road warrior use case (full-tunnel for privacy on untrusted networks), so split-tunnel is documented as a manual post-install configuration rather than a built-in feature.

Closes #547.