### PR TITLE
fix(test): pass Docker env vars to systemd test service

### DIFF
--- a/test/Dockerfile.server
+++ b/test/Dockerfile.server
@@ -71,6 +71,7 @@ COPY test/validate-output.sh /opt/test/validate-output.sh
 RUN chmod +x /entrypoint.sh /opt/test/validate-output.sh
 
 # Create systemd service for the test script
+# PassEnvironment passes Docker env vars (-e) from PID 1 to the service
 RUN printf '%s\n' \
     '[Unit]' \
     'Description=OpenVPN Installation Test' \
@@ -79,6 +80,7 @@ RUN printf '%s\n' \
     '[Service]' \
     'Type=oneshot' \
     'Environment=HOME=/root' \
+    'PassEnvironment=AUTH_MODE TLS_SIG TLS_KEY_FILE TLS_VERSION_MIN TLS13_CIPHERSUITES CLIENT_IPV6 VPN_SUBNET_IPV6' \
     'WorkingDirectory=/root' \
     'ExecStart=/entrypoint.sh' \
     'RemainAfterExit=yes' \


### PR DESCRIPTION
## Summary

- Fix fingerprint mode CI test not actually testing fingerprint mode
- Add `PassEnvironment` directive to pass Docker env vars to systemd service

## Problem

The fingerprint mode CI test (`ubuntu-24.04-fingerprint`) was **not actually testing fingerprint mode**. Docker environment variables passed with `-e AUTH_MODE=fingerprint` were not being inherited by the systemd service running the test entrypoint.

Evidence from CI logs:
```
-e AUTH_MODE=fingerprint \           # Docker receives fingerprint
...
[INFO]   AUTH_MODE=pki               # But script sees pki!
...
> ./easyrsa --batch build-client-full   # PKI command used, not self-sign-client!
```

This explains why fingerprint mode bugs (like #1444) went undetected in CI.

## Fix

Add `PassEnvironment=` directive to the systemd service definition to pass test configuration env vars from Docker (PID 1) to the test service:

- `AUTH_MODE` - authentication mode (pki/fingerprint)
- `TLS_SIG`, `TLS_KEY_FILE` - TLS settings
- `TLS_VERSION_MIN`, `TLS13_CIPHERSUITES` - TLS version config
- `CLIENT_IPV6`, `VPN_SUBNET_IPV6` - IPv6 settings

## Note

This PR only fixes the CI infrastructure. The actual fingerprint mode bugs will need separate fixes - this PR will cause the fingerprint CI job to fail, exposing the real issues.

Related: #1444