### PR TITLE
fix: support fingerprint mode in client management operations

### DIFF
--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -3621,7 +3621,7 @@ function selectClient() {
 			expiry=$(formatExpiry "$days")
 			echo "     $i) $client $expiry"
 			((i++))
-		done <<< "$clients_list"
+		done <<<"$clients_list"
 	else
 		echo "$clients_list" | nl -s ') '
 	fi
@@ -3703,7 +3703,7 @@ function listClients() {
 			fi
 
 			clients_data+=("$client_name|$status_text|$expiry_date|$days_remaining")
-		done <<< "$clients_list"
+		done <<<"$clients_list"
 	else
 		# PKI mode: get clients from index.txt
 		# Exclude server certificates (CN starting with server_)

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -4120,13 +4120,15 @@ function renewClient() {
 
 	if [[ $auth_mode == "fingerprint" ]]; then
 		# Fingerprint mode: cannot use easyrsa renew (requires CA)
-		# Instead: delete old cert, generate new self-signed, update fingerprint
+		# Instead: delete old cert/key/req, generate new self-signed, update fingerprint
 
-		# Remove old certificate files (keep the key for continuity, or regenerate)
+		# Remove old certificate files (all must be removed for self-sign-client to work)
 		run_cmd "Removing old certificate" rm -f "pki/issued/$CLIENT.crt"
+		run_cmd "Removing old private key" rm -f "pki/private/$CLIENT.key"
+		run_cmd "Removing old request" rm -f "pki/reqs/$CLIENT.req"
 
 		# Generate new self-signed certificate
-		run_cmd_fatal "Generating new certificate" ./easyrsa --batch self-sign-client "$CLIENT" nopass
+		run_cmd_fatal "Generating new certificate" ./easyrsa --batch --days="$client_cert_duration_days" self-sign-client "$CLIENT" nopass
 
 		# Extract new fingerprint
 		local new_fingerprint

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -4128,7 +4128,7 @@ function renewClient() {
 		run_cmd "Removing old request" rm -f "pki/reqs/$CLIENT.req"
 
 		# Generate new self-signed certificate
-		run_cmd_fatal "Generating new certificate" ./easyrsa --batch --days="$client_cert_duration_days" self-sign-client "$CLIENT" nopass
+		run_cmd_fatal "Generating new certificate" ./easyrsa --batch self-sign-client "$CLIENT" nopass
 
 		# Extract new fingerprint
 		local new_fingerprint
@@ -4231,7 +4231,7 @@ function renewServer() {
 
 		# Generate new self-signed server certificate
 		export EASYRSA_CERT_EXPIRE=$server_cert_duration_days
-		run_cmd_fatal "Generating new server certificate" ./easyrsa --batch --days="$server_cert_duration_days" self-sign-server "$server_name" nopass
+		run_cmd_fatal "Generating new server certificate" ./easyrsa --batch self-sign-server "$server_name" nopass
 
 		# Extract the new fingerprint
 		local new_fingerprint
@@ -4256,9 +4256,8 @@ function renewServer() {
 		if [[ -n "$clients" ]]; then
 			while IFS= read -r client; do
 				if [[ -n "$client" ]] && [[ -f "pki/issued/$client.crt" ]]; then
-					local client_config_path="$HOME/$client.ovpn"
 					log_info "Regenerating config for client: $client"
-					generateClientConfig "$client" "$client_config_path"
+					CLIENT="$client" writeClientConfig "$client"
 				fi
 			done <<<"$clients"
 		fi

--- a/test/Dockerfile.server
+++ b/test/Dockerfile.server
@@ -71,6 +71,7 @@ COPY test/validate-output.sh /opt/test/validate-output.sh
 RUN chmod +x /entrypoint.sh /opt/test/validate-output.sh
 
 # Create systemd service for the test script
+# PassEnvironment passes Docker env vars (-e) from PID 1 to the service
 RUN printf '%s\n' \
     '[Unit]' \
     'Description=OpenVPN Installation Test' \
@@ -79,6 +80,7 @@ RUN printf '%s\n' \
     '[Service]' \
     'Type=oneshot' \
     'Environment=HOME=/root' \
+    'PassEnvironment=AUTH_MODE TLS_SIG TLS_KEY_FILE TLS_VERSION_MIN TLS13_CIPHERSUITES CLIENT_IPV6 VPN_SUBNET_IPV6' \
     'WorkingDirectory=/root' \
     'ExecStart=/entrypoint.sh' \
     'RemainAfterExit=yes' \

--- a/test/server-entrypoint.sh
+++ b/test/server-entrypoint.sh
@@ -538,6 +538,11 @@ done
 # Allow routing to stabilize after renewal restart
 sleep 3
 
+# Update shared client config after server renewal (fingerprint changed)
+cp /root/testclient.ovpn /shared/client.ovpn
+sed -i 's/^remote .*/remote openvpn-server 1194/' /shared/client.ovpn
+echo "Updated client config with new server fingerprint"
+
 # =====================================================
 # Verify Unbound DNS resolver (started by systemd via install script)
 # =====================================================

--- a/test/server-entrypoint.sh
+++ b/test/server-entrypoint.sh
@@ -203,7 +203,7 @@ if [ "$DUPLICATE_EXIT_CODE" -ne 1 ]; then
 	cat "$DUPLICATE_OUTPUT"
 	exit 1
 fi
-if grep -q "The specified client CN was already found in easy-rsa" "$DUPLICATE_OUTPUT"; then
+if grep -q "The specified client CN was already found" "$DUPLICATE_OUTPUT"; then
 	echo "PASS: Duplicate client name correctly rejected with exit code 1"
 else
 	echo "FAIL: Expected error message for duplicate client name not found"


### PR DESCRIPTION
## Summary

Fixes fingerprint mode (OpenVPN 2.6+ peer-fingerprint authentication) which was broken for client management operations.

### CI Fix
Docker environment variables (`AUTH_MODE`, etc.) weren't being passed to the systemd service running tests. Added `PassEnvironment` directive to fix this.

### Script Fixes
In fingerprint mode, `easyrsa self-sign-*` commands don't create/maintain `index.txt`, but several functions depended on it.

**Fixed operations:**
- `selectClient()`: uses fingerprints from server.conf instead of index.txt
- `listClients()`: scans certs in pki/issued/, marks those without fingerprint as revoked
- `newClient()`: duplicate check works in fingerprint mode, cleans up revoked cert files for name reuse
- `revokeClient()`: removes fingerprint from server.conf, keeps cert for listing
- `renewClient()`: uses `self-sign-client` instead of `easyrsa renew`
- `renewServer()`: uses `self-sign-server` + regenerates all client configs (they embed server fingerprint)

**New helpers:**
- `getAuthMode()` - returns "pki" or "fingerprint"
- `getClientsFromFingerprints()` - parses client names from server.conf
- `clientExistsInFingerprints()` - checks client existence
- `getCertExpiry()` - extracts expiry date/days from cert file
- `removeCertFiles()` - removes cert/key/req files for regeneration
- `extractFingerprint()` - gets SHA256 fingerprint from cert

Fixes #1444