### PR TITLE
Fix management socket path to persist after reboot

### DIFF
--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -3050,12 +3050,9 @@ tls-version-min $TLS_VERSION_MIN"
 tls-ciphersuites $TLS13_CIPHERSUITES
 client-config-dir ccd
 status /var/log/openvpn/status.log
-management /var/run/openvpn/server.sock unix
+management /var/run/openvpn-server/server.sock unix
 verb 3"
 	} >>/etc/openvpn/server/server.conf
-
-	# Create management socket directory
-	run_cmd_fatal "Creating management socket directory" mkdir -p /var/run/openvpn
 
 	# Create client-config-dir dir
 	run_cmd_fatal "Creating client config directory" mkdir -p /etc/openvpn/server/ccd
@@ -4096,7 +4093,7 @@ function revokeClient() {
 # Disconnect a client via the management interface
 function disconnectClient() {
 	local client_name="$1"
-	local mgmt_socket="/var/run/openvpn/server.sock"
+	local mgmt_socket="/var/run/openvpn-server/server.sock"
 
 	if [[ ! -S "$mgmt_socket" ]]; then
 		log_warn "Management socket not found. Client may still be connected until they reconnect."

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -3127,6 +3127,12 @@ verb 3"
 		run_cmd "Patching service file (paths)" sed -i 's|/etc/openvpn/|/etc/openvpn/server/|g' /etc/systemd/system/openvpn-server@.service
 	fi
 
+	# Ensure RuntimeDirectory is set for the management socket
+	# Some distros (e.g., openSUSE) don't include this in their service file
+	if ! grep -q "RuntimeDirectory=" /etc/systemd/system/openvpn-server@.service; then
+		run_cmd "Patching service file (RuntimeDirectory)" sed -i '/\[Service\]/a RuntimeDirectory=openvpn-server' /etc/systemd/system/openvpn-server@.service
+	fi
+
 	run_cmd "Reloading systemd" systemctl daemon-reload
 	run_cmd "Enabling OpenVPN service" systemctl enable openvpn-server@server
 	# In fingerprint mode, delay service start until first client is created

--- a/test/server-entrypoint.sh
+++ b/test/server-entrypoint.sh
@@ -162,7 +162,7 @@ echo ""
 echo "=== Verifying Management Interface Configuration ==="
 
 # Verify management socket is configured in server.conf
-if grep -q "management /var/run/openvpn/server.sock unix" /etc/openvpn/server/server.conf; then
+if grep -q "management /var/run/openvpn-server/server.sock unix" /etc/openvpn/server/server.conf; then
 	echo "PASS: Management interface configured in server.conf"
 else
 	echo "FAIL: Management interface not found in server.conf"
@@ -171,10 +171,10 @@ else
 fi
 
 # Verify management socket directory exists
-if [ -d /var/run/openvpn ]; then
+if [ -d /var/run/openvpn-server ]; then
 	echo "PASS: Management socket directory exists"
 else
-	echo "FAIL: Management socket directory /var/run/openvpn not found"
+	echo "FAIL: Management socket directory /var/run/openvpn-server not found"
 	exit 1
 fi
 
@@ -1149,14 +1149,14 @@ echo "=== PASSPHRASE Support Tests PASSED ==="
 echo ""
 echo "=== Testing Management Interface ==="
 
-MGMT_SOCKET="/var/run/openvpn/server.sock"
+MGMT_SOCKET="/var/run/openvpn-server/server.sock"
 
 # Verify management socket exists and is accessible
 if [ -S "$MGMT_SOCKET" ]; then
 	echo "PASS: Management socket exists at $MGMT_SOCKET"
 else
 	echo "FAIL: Management socket not found at $MGMT_SOCKET"
-	ls -la /var/run/openvpn/ || true
+	ls -la /var/run/openvpn-server/ || true
 	exit 1
 fi
 


### PR DESCRIPTION

- Use `/var/run/openvpn-server/` instead of `/var/run/openvpn/` for the management socket
- The former is created at boot by OpenVPN's tmpfiles.d, the latter was lost on reboot

Fixes #1451