### PR TITLE
Added compatibility for Linux Mint to the Debian/Ubuntu installOpenVPNRepo function

### DIFF
--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -1878,7 +1878,7 @@ https://build.openvpn.net/debian/openvpn/stable ${REPO_CODENAME} main" \
         run_cmd_fatal "Updating package lists with OpenVPN repository" apt-get update
 
         log_info "OpenVPN official repository configured"
-    fi
+    
 
 	elif [[ $OS =~ (centos|oracle) ]]; then
 		# For RHEL-based systems, use Fedora Copr (OpenVPN 2.6 stable)

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -1870,9 +1870,10 @@ function installOpenVPNRepo() {
         log_info "Using OpenVPN repository codename: $REPO_CODENAME"
 
         # Write OpenVPN repo
-        echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/openvpn-repo-public.asc] \
-https://build.openvpn.net/debian/openvpn/stable ${REPO_CODENAME} main" \
-        > /etc/apt/sources.list.d/openvpn-aptrepo.list
+        repo_line="deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/openvpn-repo-public.asc] https://build.openvpn.net/debian/openvpn/stable ${REPO_CODENAME} main"
+
+		echo "$repo_line" >/etc/apt/sources.list.d/openvpn-aptrepo.list
+
 
         # Update with OpenVPN repo enabled
         run_cmd_fatal "Updating package lists with OpenVPN repository" apt-get update


### PR DESCRIPTION
Added compatibility for Linux Mint to the Debian/Ubuntu installOpenVPNRepo() function
I have tested and confirmed that the code changes work on my Linux Mint laptop. Mint utilizes Ubuntu repos anyways, so it was a fairly minor change.  I also tested and confirmed its backwards compatibility with my headless Debian Server.