### PR TITLE
Fix Easy-RSA download when HOME is unset

### DIFF
--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -2715,17 +2715,20 @@ function installOpenVPN() {
 
 	# Install the latest version of easy-rsa from source, if not already installed.
 	if [[ ! -d /etc/openvpn/server/easy-rsa/ ]]; then
-		run_cmd_fatal "Downloading Easy-RSA v${EASYRSA_VERSION}" curl -fL --retry 5 -o ~/easy-rsa.tgz "https://github.com/OpenVPN/easy-rsa/releases/download/v${EASYRSA_VERSION}/EasyRSA-${EASYRSA_VERSION}.tgz"
+		local easy_rsa_archive
+		easy_rsa_archive=$(mktemp /tmp/easy-rsa.XXXXXX.tgz) || log_fatal "Failed to create temporary Easy-RSA archive"
+
+		run_cmd_fatal "Downloading Easy-RSA v${EASYRSA_VERSION}" curl -fL --retry 5 -o "$easy_rsa_archive" "https://github.com/OpenVPN/easy-rsa/releases/download/v${EASYRSA_VERSION}/EasyRSA-${EASYRSA_VERSION}.tgz"
 		log_info "Verifying Easy-RSA checksum..."
-		CHECKSUM_OUTPUT=$(echo "${EASYRSA_SHA256}  $HOME/easy-rsa.tgz" | sha256sum -c 2>&1) || {
+		CHECKSUM_OUTPUT=$(echo "${EASYRSA_SHA256}  $easy_rsa_archive" | sha256sum -c 2>&1) || {
 			_log_to_file "[CHECKSUM] $CHECKSUM_OUTPUT"
-			run_cmd "Cleaning up failed download" rm -f ~/easy-rsa.tgz
+			run_cmd "Cleaning up failed download" rm -f "$easy_rsa_archive"
 			log_fatal "SHA256 checksum verification failed for easy-rsa download!"
 		}
 		_log_to_file "[CHECKSUM] $CHECKSUM_OUTPUT"
 		run_cmd_fatal "Creating Easy-RSA directory" mkdir -p /etc/openvpn/server/easy-rsa
-		run_cmd_fatal "Extracting Easy-RSA" tar xzf ~/easy-rsa.tgz --strip-components=1 --no-same-owner --directory /etc/openvpn/server/easy-rsa
-		run_cmd "Cleaning up archive" rm -f ~/easy-rsa.tgz
+		run_cmd_fatal "Extracting Easy-RSA" tar xzf "$easy_rsa_archive" --strip-components=1 --no-same-owner --directory /etc/openvpn/server/easy-rsa
+		run_cmd "Cleaning up archive" rm -f "$easy_rsa_archive"
 
 		cd /etc/openvpn/server/easy-rsa/ || return
 		case $CERT_TYPE in

--- a/test/server-entrypoint.sh
+++ b/test/server-entrypoint.sh
@@ -128,11 +128,12 @@ fi
 
 echo "Running OpenVPN install script..."
 echo "Command: ${INSTALL_CMD[*]}"
+echo "Running install with HOME unset to match cloud-init user-data environments"
 # Run in subshell because the script calls 'exit 0' after generating client config
 # Capture output to validate logging format, while still displaying it
 # Use || true to prevent set -e from exiting on failure, then check exit code
 INSTALL_OUTPUT="/tmp/install-output.log"
-("${INSTALL_CMD[@]}") 2>&1 | tee "$INSTALL_OUTPUT"
+(env -u HOME "${INSTALL_CMD[@]}") 2>&1 | tee "$INSTALL_OUTPUT"
 INSTALL_EXIT_CODE=${PIPESTATUS[0]}
 
 echo "=== Installation complete (exit code: $INSTALL_EXIT_CODE) ==="


### PR DESCRIPTION
Use a temporary Easy-RSA archive path instead of mixing `~` and `$HOME`, since cloud-init/user-data environments may not export `HOME`.

The Docker server test now runs the install with `HOME` unset to cover that environment.

Fixes #1488.
