### PR TITLE
Handle unsupported OpenVPN APT suites

### DIFF
--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -36,6 +36,8 @@ jobs:
             image: debian:11
           - name: debian-12
             image: debian:12
+          - name: debian-sid
+            image: debian:sid
           - name: centos-stream-9
             image: quay.io/centos/centos:stream9
           - name: centos-stream-10

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -137,7 +137,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Build server image
         run: |

--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,9 @@ test-debian-11:
 test-debian-12:
 	$(MAKE) test BASE_IMAGE=debian:12
 
+test-debian-sid:
+	$(MAKE) test BASE_IMAGE=debian:sid
+
 test-fedora-40:
 	$(MAKE) test BASE_IMAGE=fedora:40
 
@@ -125,6 +128,7 @@ test-all:
 	$(MAKE) test-ubuntu-24.04
 	$(MAKE) test-debian-11
 	$(MAKE) test-debian-12
+	$(MAKE) test-debian-sid
 	$(MAKE) test-fedora-40
 	$(MAKE) test-fedora-41
 	$(MAKE) test-rocky-8

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -1834,8 +1834,24 @@ function installOpenVPNRepo() {
 	log_info "Setting up official OpenVPN repository..."
 
 	if [[ $OS =~ (debian|ubuntu) ]]; then
+		local repo_url="https://build.openvpn.net/debian/openvpn/stable"
+		local repo_list="/etc/apt/sources.list.d/openvpn-aptrepo.list"
+
+		# Remove configuration left by an interrupted or failed installation so
+		# that it cannot prevent the prerequisite package update.
+		if [[ -e $repo_list ]]; then
+			run_cmd_fatal "Removing existing OpenVPN repository configuration" rm -f "$repo_list"
+		fi
+
 		run_cmd_fatal "Update package lists" apt-get update
 		run_cmd_fatal "Installing prerequisites" apt-get install -y ca-certificates curl
+
+		# The OpenVPN repository does not publish packages for every Debian and
+		# Ubuntu suite. This commonly affects Debian testing and unstable.
+		if [[ -z ${VERSION_CODENAME:-} ]] || ! curl -fsL --connect-timeout 10 --max-time 30 -o /dev/null "${repo_url}/dists/${VERSION_CODENAME}/Release"; then
+			log_warn "Official OpenVPN repository is unavailable for ${VERSION_CODENAME:-this distribution}; using distribution packages"
+			return 0
+		fi
 
 		# Create keyrings directory
 		run_cmd "Creating keyrings directory" mkdir -p /etc/apt/keyrings
@@ -1846,10 +1862,7 @@ function installOpenVPNRepo() {
 		fi
 
 		# Add repository - using stable release
-		if [[ -z "${VERSION_CODENAME}" ]]; then
-			log_fatal "VERSION_CODENAME is not set. Unable to configure OpenVPN repository."
-		fi
-		echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/openvpn-repo-public.asc] https://build.openvpn.net/debian/openvpn/stable ${VERSION_CODENAME} main" >/etc/apt/sources.list.d/openvpn-aptrepo.list
+		echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/openvpn-repo-public.asc] ${repo_url} ${VERSION_CODENAME} main" >"$repo_list"
 
 		log_info "Updating package lists with new repository..."
 		run_cmd_fatal "Update package lists" apt-get update

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -1837,6 +1837,7 @@ function installOpenVPNRepo() {
 	if [[ $OS =~ (debian|ubuntu) ]]; then
 		local repo_url="https://build.openvpn.net/debian/openvpn/stable"
 		local repo_list="/etc/apt/sources.list.d/openvpn-aptrepo.list"
+		local repo_status
 
 		# Remove configuration left by an interrupted or failed installation so
 		# that it cannot prevent the prerequisite package update.
@@ -1849,9 +1850,20 @@ function installOpenVPNRepo() {
 
 		# The OpenVPN repository does not publish packages for every Debian and
 		# Ubuntu suite. This commonly affects Debian testing and unstable.
-		if [[ -z ${VERSION_CODENAME:-} ]] || ! curl -fsL --connect-timeout 10 --max-time 30 -o /dev/null "${repo_url}/dists/${VERSION_CODENAME}/Release"; then
-			log_warn "Official OpenVPN repository is unavailable for ${VERSION_CODENAME:-this distribution}; using distribution packages"
+		if [[ -z ${VERSION_CODENAME:-} ]]; then
+			log_warn "Distribution codename is unavailable; using distribution packages"
 			return 0
+		fi
+
+		if ! repo_status=$(curl -sL --connect-timeout 10 --max-time 30 -o /dev/null -w "%{http_code}" "${repo_url}/dists/${VERSION_CODENAME}/Release"); then
+			log_fatal "Failed to check OpenVPN repository availability for ${VERSION_CODENAME}"
+		fi
+
+		if [[ $repo_status == "404" ]]; then
+			log_warn "Official OpenVPN repository does not publish packages for ${VERSION_CODENAME}; using distribution packages"
+			return 0
+		elif [[ $repo_status != "200" ]]; then
+			log_fatal "OpenVPN repository availability check returned HTTP ${repo_status} for ${VERSION_CODENAME}"
 		fi
 
 		# Create keyrings directory

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -1633,7 +1633,8 @@ function checkOS() {
 		source /etc/os-release
 
 		if [[ $ID == "debian" || $ID == "raspbian" ]]; then
-			if [[ $VERSION_ID -lt 11 ]]; then
+			# Debian testing and unstable do not set VERSION_ID.
+			if [[ -n ${VERSION_ID:-} && $VERSION_ID -lt 11 ]]; then
 				log_warn "Your version of Debian is not supported."
 				log_info "However, if you're using Debian >= 11 or unstable/testing, you can continue at your own risk."
 				until [[ $CONTINUE =~ (y|n) ]]; do


### PR DESCRIPTION
## Summary

- check that the official OpenVPN APT repository publishes the detected suite before configuring it
- fall back to distribution packages for unsupported suites such as Debian Sid/Forky
- remove stale repository configuration so failed installations can be retried
- add Debian Sid to the Docker test matrix

Closes #1498