### PR TITLE
Fix firewall backend installation

### DIFF
--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -1854,8 +1854,9 @@ cmd_interactive() {
 	if isOpenVPNInstalled; then
 		manageMenu
 	else
-		installQuestions
-		installOpenVPN
+		# Reuse the install command so interactive installs receive the same
+		# validation and derived network configuration as non-interactive installs.
+		cmd_install --interactive
 	fi
 }
 
@@ -2426,6 +2427,17 @@ function detect_server_ips() {
 		IP="$IP_IPV6"
 	else
 		IP="$IP_IPV4"
+	fi
+}
+
+# Select the active firewall manager, with iptables as the fallback.
+function detect_firewall_backend() {
+	if systemctl is-active --quiet firewalld; then
+		echo firewalld
+	elif systemctl is-active --quiet nftables; then
+		echo nftables
+	else
+		echo iptables
 	fi
 }
 
@@ -3047,6 +3059,10 @@ function installOpenVPN() {
 		fi
 	fi
 
+	# Select the firewall backend before installing dependencies so native
+	# firewalld and nftables systems do not need the iptables package.
+	FIREWALL_BACKEND=$(detect_firewall_backend)
+
 	# If OpenVPN isn't installed yet, install it. This script is more-or-less
 	# idempotent on multiple runs, but will only install OpenVPN from upstream
 	# the first time.
@@ -3057,21 +3073,26 @@ function installOpenVPN() {
 		installOpenVPNRepo
 
 		log_info "Installing OpenVPN and dependencies..."
-		# socat is used for communicating with the OpenVPN management interface (client disconnect on revoke)
+		# iptables is only required by the fallback backend. socat communicates
+		# with the OpenVPN management interface for client disconnect on revoke.
+		local -a firewall_packages=()
+		if [[ $FIREWALL_BACKEND == 'iptables' ]]; then
+			firewall_packages+=(iptables)
+		fi
 		if [[ $OS =~ (debian|ubuntu) ]]; then
-			run_cmd_fatal "Installing OpenVPN" apt-get install -y openvpn iptables openssl curl ca-certificates tar dnsutils socat
+			run_cmd_fatal "Installing OpenVPN" apt-get install -y openvpn "${firewall_packages[@]}" openssl curl ca-certificates tar dnsutils socat
 		elif [[ $OS == 'centos' ]]; then
-			run_cmd_fatal "Installing OpenVPN" yum install -y openvpn iptables openssl ca-certificates curl tar bind-utils socat 'policycoreutils-python*'
+			run_cmd_fatal "Installing OpenVPN" yum install -y openvpn "${firewall_packages[@]}" openssl ca-certificates curl tar bind-utils socat 'policycoreutils-python*'
 		elif [[ $OS == 'oracle' ]]; then
-			run_cmd_fatal "Installing OpenVPN" yum install -y openvpn iptables openssl ca-certificates curl tar bind-utils socat policycoreutils-python-utils
+			run_cmd_fatal "Installing OpenVPN" yum install -y openvpn "${firewall_packages[@]}" openssl ca-certificates curl tar bind-utils socat policycoreutils-python-utils
 		elif [[ $OS == 'amzn2023' ]]; then
-			run_cmd_fatal "Installing OpenVPN" dnf install -y openvpn iptables openssl ca-certificates curl tar bind-utils socat
+			run_cmd_fatal "Installing OpenVPN" dnf install -y openvpn "${firewall_packages[@]}" openssl ca-certificates curl tar bind-utils socat
 		elif [[ $OS == 'fedora' ]]; then
-			run_cmd_fatal "Installing OpenVPN" dnf install -y openvpn iptables openssl ca-certificates curl tar bind-utils socat policycoreutils-python-utils
+			run_cmd_fatal "Installing OpenVPN" dnf install -y openvpn "${firewall_packages[@]}" openssl ca-certificates curl tar bind-utils socat policycoreutils-python-utils
 		elif [[ $OS == 'opensuse' ]]; then
-			run_cmd_fatal "Installing OpenVPN" zypper install -y openvpn iptables openssl ca-certificates curl tar bind-utils socat
+			run_cmd_fatal "Installing OpenVPN" zypper install -y openvpn "${firewall_packages[@]}" openssl ca-certificates curl tar bind-utils socat
 		elif [[ $OS == 'arch' ]]; then
-			run_cmd_fatal "Installing OpenVPN" pacman --needed --noconfirm -Syu openvpn iptables openssl ca-certificates curl tar bind socat
+			run_cmd_fatal "Installing OpenVPN" pacman --needed --noconfirm -Syu openvpn "${firewall_packages[@]}" openssl ca-certificates curl tar bind socat
 		fi
 
 		# Verify ChaCha20-Poly1305 compatibility if selected
@@ -3493,13 +3514,6 @@ verb 3"
 	} >>/etc/openvpn/server/server.conf
 
 	# Record installer-owned policy so firewall rules can be removed exactly.
-	if systemctl is-active --quiet firewalld; then
-		FIREWALL_BACKEND=firewalld
-	elif systemctl is-active --quiet nftables; then
-		FIREWALL_BACKEND=nftables
-	else
-		FIREWALL_BACKEND=iptables
-	fi
 	{
 		echo "FIREWALL_BACKEND=$FIREWALL_BACKEND"
 		echo "ROUTE_INTERNET=$ROUTE_INTERNET"

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -2276,6 +2276,12 @@ function installUnbound() {
 		fi
 	fi
 
+	# openSUSE ships the DNSSEC root trust anchor updater separately. Ensure the
+	# anchor can follow root key rollovers before starting the resolver.
+	if [[ $OS == "opensuse" ]] && ! command -v unbound-anchor >/dev/null; then
+		run_cmd_fatal "Installing Unbound trust anchor updater" zypper install -y unbound-anchor
+	fi
+
 	# Configure Unbound for OpenVPN (runs whether freshly installed or pre-existing)
 	# Create conf.d directory (works on all distros)
 	run_cmd "Creating Unbound config directory" mkdir -p /etc/unbound/unbound.conf.d
@@ -2343,6 +2349,9 @@ function installUnbound() {
 		fi
 	} >/etc/unbound/unbound.conf.d/openvpn.conf
 
+	if [[ $OS == "opensuse" ]]; then
+		run_cmd_fatal "Updating Unbound root trust anchor" systemctl start unbound-anchor.service
+	fi
 	run_cmd "Enabling Unbound service" systemctl enable unbound
 	run_cmd "Starting Unbound service" systemctl restart unbound
 

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -3071,6 +3071,15 @@ function installOpenVPN() {
 	# Select the firewall backend before installing dependencies so native
 	# firewalld and nftables systems do not need the iptables package.
 	FIREWALL_BACKEND=$(detect_firewall_backend)
+	FIREWALLD_PORT_ZONE=""
+	if [[ $FIREWALL_BACKEND == 'firewalld' ]]; then
+		if [[ -n $NIC ]]; then
+			FIREWALLD_PORT_ZONE=$(firewall-cmd --get-zone-of-interface="$NIC" 2>/dev/null || true)
+		fi
+		if [[ -z $FIREWALLD_PORT_ZONE || $FIREWALLD_PORT_ZONE == 'no zone' ]]; then
+			FIREWALLD_PORT_ZONE=$(firewall-cmd --get-default-zone)
+		fi
+	fi
 
 	# If OpenVPN isn't installed yet, install it. This script is more-or-less
 	# idempotent on multiple runs, but will only install OpenVPN from upstream
@@ -3525,6 +3534,7 @@ verb 3"
 	# Record installer-owned policy so firewall rules can be removed exactly.
 	{
 		echo "FIREWALL_BACKEND=$FIREWALL_BACKEND"
+		echo "FIREWALLD_PORT_ZONE=$FIREWALLD_PORT_ZONE"
 		echo "ROUTE_INTERNET=$ROUTE_INTERNET"
 		echo "CLIENT_TO_CLIENT=$CLIENT_TO_CLIENT"
 		echo "LOCAL_NETWORKS=$LOCAL_NETWORKS"
@@ -3651,7 +3661,7 @@ verb 3"
 		# destination rules to forwarded traffic; zone rich rules alone only
 		# govern traffic addressed to the server.
 		log_info "firewalld detected, using firewall-cmd..."
-		run_cmd_fatal "Adding OpenVPN port to firewalld" firewall-cmd --permanent --add-port="$PORT/$PROTOCOL"
+		run_cmd_fatal "Adding OpenVPN port to firewalld zone $FIREWALLD_PORT_ZONE" firewall-cmd --permanent --zone="$FIREWALLD_PORT_ZONE" --add-port="$PORT/$PROTOCOL"
 		run_cmd_fatal "Creating OpenVPN firewalld zone" firewall-cmd --permanent --new-zone=openvpn-install
 		run_cmd_fatal "Creating OpenVPN firewalld policy" firewall-cmd --permanent --new-policy=openvpn-egress
 		run_cmd_fatal "Setting OpenVPN policy ingress" firewall-cmd --permanent --policy=openvpn-egress --add-ingress-zone=openvpn-install
@@ -5045,6 +5055,7 @@ function removeOpenVPN() {
 		if [[ -f $install_config ]]; then
 			has_policy_manifest=y
 			FIREWALL_BACKEND=$(grep '^FIREWALL_BACKEND=' "$install_config" | cut -d= -f2-)
+			FIREWALLD_PORT_ZONE=$(grep '^FIREWALLD_PORT_ZONE=' "$install_config" | cut -d= -f2- || true)
 			ROUTE_INTERNET=$(grep '^ROUTE_INTERNET=' "$install_config" | cut -d= -f2-)
 			CLIENT_TO_CLIENT=$(grep '^CLIENT_TO_CLIENT=' "$install_config" | cut -d= -f2-)
 			LOCAL_NETWORKS=$(grep '^LOCAL_NETWORKS=' "$install_config" | cut -d= -f2-)
@@ -5064,7 +5075,14 @@ function removeOpenVPN() {
 		# Remove firewall rules
 		log_info "Removing firewall rules..."
 		if systemctl is-active --quiet firewalld && { [[ $has_policy_manifest == 'y' && $FIREWALL_BACKEND == 'firewalld' ]] || { [[ $has_policy_manifest == 'n' ]] && firewall-cmd --list-ports | grep -q "$PORT/$PROTOCOL_BASE"; }; }; then
-			run_cmd "Removing OpenVPN port from firewalld" firewall-cmd --permanent --remove-port="$PORT/$PROTOCOL_BASE"
+			if [[ $has_policy_manifest == 'y' ]]; then
+				if [[ -z $FIREWALLD_PORT_ZONE ]]; then
+					FIREWALLD_PORT_ZONE=$(firewall-cmd --get-default-zone)
+				fi
+				run_cmd "Removing OpenVPN port from firewalld zone $FIREWALLD_PORT_ZONE" firewall-cmd --permanent --zone="$FIREWALLD_PORT_ZONE" --remove-port="$PORT/$PROTOCOL_BASE"
+			else
+				run_cmd "Removing OpenVPN port from firewalld" firewall-cmd --permanent --remove-port="$PORT/$PROTOCOL_BASE"
+			fi
 			if [[ $has_policy_manifest == 'y' ]]; then
 				firewall-cmd --permanent --delete-policy=openvpn-egress 2>/dev/null || true
 				firewall-cmd --permanent --delete-zone=openvpn-install 2>/dev/null || true

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -2258,6 +2258,13 @@ function installOpenVPNRepo() {
 	fi
 }
 
+# unbound-anchor returns 1 when it successfully replaces the anchor.
+function refreshUnboundTrustAnchor() {
+	local status=0
+	runuser -u unbound -- unbound-anchor -F || status=$?
+	[[ $status -le 1 ]]
+}
+
 function installUnbound() {
 	log_info "Installing Unbound DNS resolver..."
 
@@ -2276,10 +2283,19 @@ function installUnbound() {
 		fi
 	fi
 
-	# openSUSE ships the DNSSEC root trust anchor updater separately. Ensure the
-	# anchor can follow root key rollovers before starting the resolver.
-	if [[ $OS == "opensuse" ]] && ! command -v unbound-anchor >/dev/null; then
-		run_cmd_fatal "Installing Unbound trust anchor updater" zypper install -y unbound-anchor
+	# Some distributions ship the DNSSEC root trust anchor updater separately.
+	if ! command -v unbound-anchor >/dev/null; then
+		if [[ $OS =~ (debian|ubuntu) ]]; then
+			run_cmd_fatal "Installing Unbound trust anchor updater" apt-get install -y unbound-anchor
+		elif [[ $OS =~ (centos|oracle) ]]; then
+			run_cmd_fatal "Installing Unbound trust anchor updater" yum install -y unbound-anchor
+		elif [[ $OS =~ (fedora|amzn2023) ]]; then
+			run_cmd_fatal "Installing Unbound trust anchor updater" dnf install -y unbound-anchor
+		elif [[ $OS == "opensuse" ]]; then
+			run_cmd_fatal "Installing Unbound trust anchor updater" zypper install -y unbound-anchor
+		elif [[ $OS == "arch" ]]; then
+			run_cmd_fatal "Installing Unbound trust anchor updater" pacman -S --noconfirm unbound
+		fi
 	fi
 
 	# Configure Unbound for OpenVPN (runs whether freshly installed or pre-existing)
@@ -2349,9 +2365,7 @@ function installUnbound() {
 		fi
 	} >/etc/unbound/unbound.conf.d/openvpn.conf
 
-	if [[ $OS == "opensuse" ]]; then
-		run_cmd_fatal "Updating Unbound root trust anchor" systemctl start unbound-anchor.service
-	fi
+	run_cmd_fatal "Refreshing Unbound root trust anchor" refreshUnboundTrustAnchor
 	run_cmd "Enabling Unbound service" systemctl enable unbound
 	run_cmd "Starting Unbound service" systemctl restart unbound
 

--- a/test/Dockerfile.server
+++ b/test/Dockerfile.server
@@ -18,7 +18,7 @@ ENV ENABLE_NFTABLES=${ENABLE_NFTABLES}
 # Note: socat is installed by openvpn-install.sh during OpenVPN installation
 RUN if command -v apt-get >/dev/null; then \
         apt-get update && apt-get install -y --no-install-recommends \
-            iproute2 iptables curl procps systemd systemd-sysv dnsutils jq \
+            iproute2 curl procps systemd systemd-sysv dnsutils jq \
         && if [ "$ENABLE_NFTABLES" = "y" ]; then apt-get install -y --no-install-recommends nftables; fi \
         && rm -rf /var/lib/apt/lists/*; \
     elif command -v dnf >/dev/null; then \
@@ -69,7 +69,8 @@ RUN chmod +x /opt/openvpn-install.sh
 COPY test/server-entrypoint.sh /entrypoint.sh
 COPY test/validate-output.sh /opt/test/validate-output.sh
 COPY test/local-network-detection.sh /opt/test/local-network-detection.sh
-RUN chmod +x /entrypoint.sh /opt/test/validate-output.sh /opt/test/local-network-detection.sh
+COPY test/interactive-install-flow.sh /opt/test/interactive-install-flow.sh
+RUN chmod +x /entrypoint.sh /opt/test/validate-output.sh /opt/test/local-network-detection.sh /opt/test/interactive-install-flow.sh
 
 # Create systemd service for the test script
 # PassEnvironment passes Docker env vars (-e) from PID 1 to the service

--- a/test/Dockerfile.server
+++ b/test/Dockerfile.server
@@ -77,7 +77,7 @@ RUN chmod +x /entrypoint.sh /opt/test/validate-output.sh /opt/test/local-network
 RUN printf '%s\n' \
     '[Unit]' \
     'Description=OpenVPN Installation Test' \
-    'After=network.target' \
+    'After=network.target firewalld.service nftables.service' \
     '' \
     '[Service]' \
     'Type=oneshot' \

--- a/test/client-entrypoint.sh
+++ b/test/client-entrypoint.sh
@@ -131,7 +131,7 @@ wait_for_revoked_reconnect_rejected() {
 
 test_dns_resolution() {
 	local label="$1"
-	local test_name="github.com"
+	local test_name="neverssl.com"
 	local success=false
 	# This verifies recursive DNS connectivity. Use an unsigned zone so the test
 	# does not depend on DNSSEC key retrieval over GitHub runner networks.

--- a/test/interactive-install-flow.sh
+++ b/test/interactive-install-flow.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# shellcheck disable=SC1091,SC2034
+# SC1091: The installer path is provided by the test environment.
+# SC2034: Configuration globals are consumed by sourced installer functions.
+set -euo pipefail
+
+INSTALLER=${1:-/opt/openvpn-install.sh}
+export FORCE_COLOR=0 LOG_FILE="" NON_INTERACTIVE_INSTALL=n OUTPUT_FORMAT=table
+# shellcheck source=../openvpn-install.sh
+source "$INSTALLER"
+
+questions_called=n
+validation_called=n
+install_called=n
+
+isOpenVPNInstalled() {
+	return 1
+}
+
+requireNoOpenVPN() {
+	return 0
+}
+
+installQuestions() {
+	questions_called=y
+	VPN_SUBNET_IPV4=10.23.0.0
+	VPN_SUBNET_IPV6=fd42:23::
+	CLIENT_IPV6=n
+	ROUTE_INTERNET=y
+}
+
+validate_configuration() {
+	validation_called=y
+}
+
+installOpenVPN() {
+	install_called=y
+	if [[ ${VPN_GATEWAY_IPV4:-} != "10.23.0.1" ]]; then
+		echo "FAIL: Interactive install did not prepare the IPv4 VPN gateway" >&2
+		exit 1
+	fi
+	if [[ ${IPV6_SUPPORT:-} != "n" ]]; then
+		echo "FAIL: Interactive install did not prepare legacy IPv6 state" >&2
+		exit 1
+	fi
+}
+
+cmd_interactive
+
+for state in \
+	"questions_called:$questions_called" \
+	"validation_called:$validation_called" \
+	"install_called:$install_called"; do
+	if [[ ${state#*:} != "y" ]]; then
+		echo "FAIL: Interactive install skipped ${state%%:*}" >&2
+		exit 1
+	fi
+done
+
+echo "PASS: Interactive install prepares derived network configuration"

--- a/test/server-entrypoint.sh
+++ b/test/server-entrypoint.sh
@@ -4,6 +4,7 @@ set -e
 echo "=== OpenVPN Server Container ==="
 
 /opt/test/local-network-detection.sh /opt/openvpn-install.sh
+/opt/test/interactive-install-flow.sh /opt/openvpn-install.sh
 
 # Create TUN device if it doesn't exist
 if [ ! -c /dev/net/tun ]; then
@@ -184,6 +185,21 @@ if [ "$INSTALL_EXIT_CODE" -ne 0 ]; then
 	echo "ERROR: Install script failed with exit code $INSTALL_EXIT_CODE"
 	exit 1
 fi
+
+# Native firewall backends must not require the iptables package. The fallback
+# backend must install it because the test image does not include it.
+if systemctl is-active --quiet firewalld || systemctl is-active --quiet nftables; then
+	if command -v dpkg-query >/dev/null && dpkg-query -W -f='${db:Status-Abbrev}' iptables 2>/dev/null | grep -q '^ii'; then
+		echo "FAIL: iptables was installed with a native firewall backend"
+		exit 1
+	fi
+else
+	if ! command -v iptables >/dev/null; then
+		echo "FAIL: iptables fallback dependency was not installed"
+		exit 1
+	fi
+fi
+echo "PASS: Firewall dependencies match the selected backend"
 
 # Verify all expected files were created
 echo "Verifying installation..."

--- a/test/server-entrypoint.sh
+++ b/test/server-entrypoint.sh
@@ -6,6 +6,15 @@ echo "=== OpenVPN Server Container ==="
 /opt/test/local-network-detection.sh /opt/openvpn-install.sh
 /opt/test/interactive-install-flow.sh /opt/openvpn-install.sh
 
+# Verify that the installer uses the zone bound to the public interface, not
+# firewalld's default zone.
+if systemctl is-active --quiet firewalld; then
+	FIREWALLD_TEST_INTERFACE=$(ip -4 route ls | awk '/^default / { for (i = 1; i <= NF; i++) if ($i == "dev") { print $(i + 1); exit } }')
+	firewall-cmd --set-default-zone=public >/dev/null
+	firewall-cmd --permanent --zone=external --change-interface="$FIREWALLD_TEST_INTERFACE" >/dev/null
+	firewall-cmd --reload >/dev/null
+fi
+
 # Create TUN device if it doesn't exist
 if [ ! -c /dev/net/tun ]; then
 	mkdir -p /dev/net
@@ -301,6 +310,10 @@ for setting in "ROUTE_INTERNET=$ROUTE_INTERNET" "CLIENT_TO_CLIENT=$CLIENT_TO_CLI
 		exit 1
 	}
 done
+if systemctl is-active --quiet firewalld && ! grep -Fxq 'FIREWALLD_PORT_ZONE=external' /etc/openvpn/server/openvpn-install.conf; then
+	echo "FAIL: Policy manifest is missing the public interface's firewalld zone"
+	exit 1
+fi
 
 echo "PASS: Access policy configuration is correct"
 
@@ -831,11 +844,17 @@ if systemctl is-active --quiet firewalld; then
 		echo "FAIL: firewalld zone-wide masquerade should not be enabled"
 		exit 1
 	fi
-	if firewall-cmd --list-ports | grep -q "1194/udp"; then
-		echo "PASS: OpenVPN port is open in firewalld"
+	FIREWALLD_PORT_ZONE=$(grep '^FIREWALLD_PORT_ZONE=' /etc/openvpn/server/openvpn-install.conf | cut -d= -f2-)
+	if firewall-cmd --zone="$FIREWALLD_PORT_ZONE" --query-port="1194/udp"; then
+		echo "PASS: OpenVPN port is open in the public interface's firewalld zone"
 	else
-		echo "FAIL: OpenVPN port not found in firewalld"
-		firewall-cmd --list-ports
+		echo "FAIL: OpenVPN port not found in firewalld zone $FIREWALLD_PORT_ZONE"
+		firewall-cmd --zone="$FIREWALLD_PORT_ZONE" --list-ports
+		exit 1
+	fi
+	FIREWALLD_DEFAULT_ZONE=$(firewall-cmd --get-default-zone)
+	if [ "$FIREWALLD_DEFAULT_ZONE" != "$FIREWALLD_PORT_ZONE" ] && firewall-cmd --zone="$FIREWALLD_DEFAULT_ZONE" --query-port="1194/udp"; then
+		echo "FAIL: OpenVPN port was also added to firewalld's default zone"
 		exit 1
 	fi
 elif systemctl is-active --quiet nftables; then


### PR DESCRIPTION
## Summary

- prepare derived network settings for interactive installs before firewall configuration
- detect the active firewall backend before package installation
- install iptables only when it is the selected fallback backend
- add regression coverage for interactive setup and firewall dependencies

Fixes #1506
Fixes #1507