### PR TITLE
Fix missing VPN Gateway when installing Unbound if IPv4/IPv6 is disabled

### DIFF
--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -2294,12 +2294,16 @@ function installUnbound() {
 
 		# IPv4 VPN interface (only if clients get IPv4)
 		if [[ $CLIENT_IPV4 == 'y' ]]; then
+			# Infer gateway from subnet
+			VPN_GATEWAY_IPV4="${VPN_SUBNET_IPV4%.*}.1"
 			echo "    interface: $VPN_GATEWAY_IPV4"
 			echo "    access-control: $VPN_SUBNET_IPV4/24 allow"
 		fi
 
 		# IPv6 VPN interface (only if clients get IPv6)
 		if [[ $CLIENT_IPV6 == 'y' ]]; then
+			# Infer gateway from subnet
+			VPN_GATEWAY_IPV6="${VPN_SUBNET_IPV6}1"
 			echo "    interface: $VPN_GATEWAY_IPV6"
 			echo "    access-control: ${VPN_SUBNET_IPV6}/112 allow"
 		fi


### PR DESCRIPTION
## Issue
In [installUnbound()](https://github.com/angristan/openvpn-install/blob/d2fc6d444bb7fef9ad30dd0fb21ae38708e65e3f/openvpn-install.sh#L2260) function, when the user selects:

-  "_1) IPv4 only_" 
- combined with "_2) Self-hosted DNS Resolve (Unbound)_"

The variable [`VPN_GATEWAY_IPV4`](https://github.com/angristan/openvpn-install/blob/d2fc6d444bb7fef9ad30dd0fb21ae38708e65e3f/openvpn-install.sh#L2297) is never set ; resulting in a missing interface value during the creation of the `/etc/unbound/unbound.conf.d/openvpn.conf` file.
This violates the interface directive and breaks the installation.

## To reproduce
On Ubuntu 22.04.4 LTS:
```bash 
sudo ./openvpn-install.sh interactive
```

=== OpenVPN Installer ===

The git repository is available at: https://github.com/angristan/openvpn-install
I need to ask you a few questions before starting the setup.
You can leave the default options and just press enter if you are okay with them.

Detecting server IP addresses...
  IPv4 address detected: XXX.XXX.XXX.XXX
  IPv6 address detected: XXXX:XXXX::XXXX:XXXX:XXXX:XXXX

What IP version should clients use to connect to this server?
   1) IPv4
   2) IPv6
Endpoint type [1-2]: 1

Server listening IPv4 address:
IPv4 address: XXX.XXX.XXX.XXX

What IP versions should VPN clients use?
This determines both their VPN addresses and internet access through the tunnel.
   1) IPv4 only
   2) IPv6 only
   3) Dual-stack (IPv4 + IPv6)
Client IP versions [1-3]: 1

IPv4 VPN subnet:
   1) Default: 10.8.0.0/24
   2) Custom
IPv4 subnet choice [1-2]: 1

What should VPN clients be allowed to access?
Route client internet traffic through the VPN? [y/n]: y
Allow VPN clients to access each other? [y/n]: n
Allow VPN clients to access the server's local network? (mainly for home servers) [y/n]: n

What port do you want OpenVPN to listen to?
   1) Default: 1194
   2) Custom
   3) Random [49152-65535]
Port choice [1-3]: 3
[INFO] Random Port: 60192

What protocol do you want OpenVPN to use?
UDP is faster. Unless it is not available, you shouldn't use TCP.
   1) UDP
   2) TCP
Protocol [1-2]: 1

What DNS resolvers do you want to use with the VPN?
   1) Current system resolvers (from /etc/resolv.conf)
   2) Self-hosted DNS Resolver (Unbound)
   3) Cloudflare (Anycast: worldwide)
   4) Quad9 (Anycast: worldwide)
   5) Quad9 uncensored (Anycast: worldwide)
   6) FDN (France)
   7) DNS.WATCH (Germany)
   8) OpenDNS (Anycast: worldwide)
   9) Google (Anycast: worldwide)
   10) Yandex Basic (Russia)
   11) AdGuard DNS (Anycast: worldwide)
   12) NextDNS (Anycast: worldwide)
   13) Custom
DNS [1-13]: 2

Do you want to allow a single .ovpn profile to be used on multiple devices simultaneously?
Note: Enabling this disables persistent IP addresses for clients.
Allow multiple devices per client? [y/n]: n

Do you want to customize the tunnel MTU?
   MTU controls the maximum packet size. Lower values can help
   with connectivity issues on some networks (e.g., PPPoE, mobile).
   1) Default (1500) - works for most networks
   2) Custom
MTU choice [1-2]: 1

Choose the authentication mode:
   1) PKI (Certificate Authority) - Traditional CA-based authentication (recommended for larger setups)
   2) Peer Fingerprint - Simplified WireGuard-like authentication using certificate fingerprints
      Note: Fingerprint mode requires OpenVPN 2.6+ and is ideal for small/home setups
Authentication mode [1-2]: 1

Do you want to customize encryption settings?
Unless you know what you're doing, you should stick with the default parameters provided by the script.
Note that whatever you choose, all the choices presented in the script are safe (unlike OpenVPN's defaults).
See https://github.com/angristan/openvpn-install#security-and-encryption to learn more.

Customize encryption settings? [y/n]: n

Okay, that was all I needed. We are ready to setup your OpenVPN server now.
You will be able to generate a client at the end of the installation.
Press any key to continue...

=== Installing OpenVPN ===

[INFO] Setting up official OpenVPN repository...
> apt-get update
> apt-get install -y ca-certificates curl
> mkdir -p /etc/apt/keyrings
> curl -fsSL https://swupdate.openvpn.net/repos/repo-public.gpg -o /etc/apt/keyrings/openvpn-repo-public.asc
[INFO] Updating package lists with new repository...
> apt-get update
[INFO] OpenVPN official repository configured
[INFO] Installing OpenVPN and dependencies...
> apt-get install -y openvpn iptables openssl curl ca-certificates tar dnsutils socat
> mkdir -p /etc/openvpn/server
> curl -fL --retry 5 -o /tmp/easy-rsa.xxxx.tgz https://github.com/OpenVPN/easy-rsa/releases/download/vxxx/EasyRSA-xxx.tgz
[INFO] Verifying Easy-RSA checksum...
> mkdir -p /etc/openvpn/server/easy-rsa
> tar xzf /tmp/easy-rsa.xxxx.tgz --strip-components=1 --no-same-owner --directory /etc/openvpn/server/easy-rsa
> rm -f /tmp/easy-rsa.xxxx.tgz
[INFO] Initializing PKI...
> ./easyrsa init-pki
[INFO] Building CA...
> ./easyrsa --batch --req-cn=cn_0000000000 build-ca nopass
[INFO] Building server certificate...
> ./easyrsa --batch build-server-full server_0000000000000 nopass
> ./easyrsa gen-crl
[INFO] Generating TLS key...
> openvpn --genkey tls-crypt-v2-server /etc/openvpn/server/tls-crypt-v2.key
[INFO] Copying certificates...
> cp pki/ca.crt pki/private/ca.key pki/issued/server_00000000.crt pki/private/server_00000000000.key /etc/openvpn/server/easy-rsa/pki/crl.pem /etc/openvpn/server
> chmod 644 /etc/openvpn/server/crl.pem
[INFO] Generating server configuration...
> mkdir -p /etc/openvpn/server/ccd
> mkdir -p /var/log/openvpn
[INFO] Enabling IP forwarding...
> mkdir -p /etc/sysctl.d
> sysctl --system
[INFO] Configuring OpenVPN service...
> cp /usr/lib/systemd/system/openvpn-server@.service /etc/systemd/system/openvpn-server@.service
> sed -i s|LimitNPROC|#LimitNPROC| /etc/systemd/system/openvpn-server@.service
> sed -i /\[Service\]/a RuntimeDirectory=openvpn-server /etc/systemd/system/openvpn-server@.service
> systemctl daemon-reload
> systemctl enable openvpn-server@server
> systemctl restart openvpn-server@server
[INFO] Installing Unbound DNS resolver...
> apt-get install -y unbound
> mkdir -p /etc/unbound/unbound.conf.d
> systemctl enable unbound
> systemctl restart unbound
[ERROR] Starting Unbound service failed with exit code 1
        Check the log file for details: openvpn-install.log
[ERROR] Unbound failed to start. Check 'journalctl -u unbound' for details.
        Check the log file for details: openvpn-install.log

## Fix
Inferring directly `VPN_GATEWAY_IPV4` from `VPN_SUBNET_IPV4` solves the issue.