### PR TITLE
Fix interactive install initialization

### DIFF
--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -1854,8 +1854,7 @@ cmd_interactive() {
 	if isOpenVPNInstalled; then
 		manageMenu
 	else
-		installQuestions
-		installOpenVPN
+		cmd_install --interactive
 	fi
 }
 

--- a/test/Dockerfile.server
+++ b/test/Dockerfile.server
@@ -68,8 +68,9 @@ RUN chmod +x /opt/openvpn-install.sh
 # Copy test scripts
 COPY test/server-entrypoint.sh /entrypoint.sh
 COPY test/validate-output.sh /opt/test/validate-output.sh
+COPY test/interactive-install-routing.sh /opt/test/interactive-install-routing.sh
 COPY test/local-network-detection.sh /opt/test/local-network-detection.sh
-RUN chmod +x /entrypoint.sh /opt/test/validate-output.sh /opt/test/local-network-detection.sh
+RUN chmod +x /entrypoint.sh /opt/test/validate-output.sh /opt/test/interactive-install-routing.sh /opt/test/local-network-detection.sh
 
 # Create systemd service for the test script
 # PassEnvironment passes Docker env vars (-e) from PID 1 to the service

--- a/test/interactive-install-routing.sh
+++ b/test/interactive-install-routing.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# shellcheck disable=SC1091,SC2034
+# SC1091: The installer path is provided by the test environment.
+# SC2034: Configuration globals are consumed by sourced installer functions.
+set -euo pipefail
+
+INSTALLER=${1:-/opt/openvpn-install.sh}
+
+export FORCE_COLOR=0 LOG_FILE="" NON_INTERACTIVE_INSTALL=n OUTPUT_FORMAT=table
+# shellcheck source=../openvpn-install.sh
+source "$INSTALLER"
+
+fail() {
+	echo "FAIL: $1" >&2
+	exit 1
+}
+
+# Exercise command orchestration without touching the host system.
+isOpenVPNInstalled() {
+	return 1
+}
+
+installQuestions() {
+	CLIENT_IPV4=y
+	CLIENT_IPV6=n
+	VPN_SUBNET_IPV4=10.8.0.0
+	ROUTE_INTERNET=y
+}
+
+validate_configuration() {
+	CONFIG_VALIDATED=y
+}
+
+installOpenVPN() {
+	[[ ${CONFIG_VALIDATED:-n} == y ]] || fail "interactive configuration was not validated"
+	[[ ${VPN_GATEWAY_IPV4:-} == 10.8.0.1 ]] || fail "IPv4 gateway was not prepared before installation"
+	[[ ${IPV6_SUPPORT:-} == n ]] || fail "legacy IPv6 support value was not prepared before installation"
+	INSTALL_CALLED=y
+}
+
+cmd_interactive
+
+[[ ${INSTALL_CALLED:-n} == y ]] || fail "interactive installation was not started"
+
+echo "PASS: Interactive command uses the canonical installation flow"

--- a/test/server-entrypoint.sh
+++ b/test/server-entrypoint.sh
@@ -3,6 +3,7 @@ set -e
 
 echo "=== OpenVPN Server Container ==="
 
+/opt/test/interactive-install-routing.sh /opt/openvpn-install.sh
 /opt/test/local-network-detection.sh /opt/openvpn-install.sh
 
 # Create TUN device if it doesn't exist


### PR DESCRIPTION
The legacy `interactive` command bypassed `cmd_install`, so it skipped configuration validation and derived gateway initialization. This left gateway values empty in Unbound DNS and firewall configuration.

Route new interactive installations through `cmd_install --interactive` so all install entry points use the same flow. Add focused coverage that checks validation and gateway preparation happen before installation.

This addresses the root cause reported in #1509.